### PR TITLE
Refactor build scripts to allow building only Classical or Mono

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+# Config
+
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes debug_symbols=no use_static_cpp=yes use_lto=yes"
+export OPTIONS="debug_symbols=no"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=no"
 export TERM=xterm
 
@@ -13,50 +15,64 @@ mkdir godot
 cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
-cp /root/mono-glue/*.cpp modules/mono/glue/
-cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+# Classical
 
-$SCONS platform=android android_arch=armv7 $OPTIONS tools=no target=release_debug
-$SCONS platform=android android_arch=armv7 $OPTIONS tools=no target=release
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for Android..."
 
-$SCONS platform=android android_arch=arm64v8 $OPTIONS tools=no target=release_debug
-$SCONS platform=android android_arch=arm64v8 $OPTIONS tools=no target=release
+  $SCONS platform=android android_arch=armv7 $OPTIONS tools=no target=release_debug
+  $SCONS platform=android android_arch=armv7 $OPTIONS tools=no target=release
 
-$SCONS platform=android android_arch=x86 $OPTIONS tools=no target=release_debug
-$SCONS platform=android android_arch=x86 $OPTIONS tools=no target=release
+  $SCONS platform=android android_arch=arm64v8 $OPTIONS tools=no target=release_debug
+  $SCONS platform=android android_arch=arm64v8 $OPTIONS tools=no target=release
 
-$SCONS platform=android android_arch=x86_64 $OPTIONS tools=no target=release_debug
-$SCONS platform=android android_arch=x86_64 $OPTIONS tools=no target=release
+  $SCONS platform=android android_arch=x86 $OPTIONS tools=no target=release_debug
+  $SCONS platform=android android_arch=x86 $OPTIONS tools=no target=release
 
-pushd platform/android/java
-./gradlew generateGodotTemplates
-popd
+  $SCONS platform=android android_arch=x86_64 $OPTIONS tools=no target=release_debug
+  $SCONS platform=android android_arch=x86_64 $OPTIONS tools=no target=release
 
-mkdir -p /root/out/templates
-cp bin/android_source.zip /root/out/templates
-cp bin/android_debug.apk /root/out/templates/android_debug.apk
-cp bin/android_release.apk /root/out/templates/android_release.apk
+  pushd platform/android/java
+  ./gradlew generateGodotTemplates
+  popd
 
-$SCONS platform=android android_arch=armv7 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-armeabi-v7a-release tools=no target=release_debug
-$SCONS platform=android android_arch=armv7 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-armeabi-v7a-release tools=no target=release
+  mkdir -p /root/out/templates
+  cp bin/android_source.zip /root/out/templates
+  cp bin/android_debug.apk /root/out/templates/android_debug.apk
+  cp bin/android_release.apk /root/out/templates/android_release.apk
+fi
 
-$SCONS platform=android android_arch=arm64v8 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-arm64-v8a-release tools=no target=release_debug
-$SCONS platform=android android_arch=arm64v8 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-arm64-v8a-release tools=no target=release
+# Mono
 
-$SCONS platform=android android_arch=x86 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86-release tools=no target=release_debug
-$SCONS platform=android android_arch=x86 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86-release tools=no target=release
+if [ "${MONO}" == "1" ]; then
+  echo "Starting Mono build for Android..."
 
-$SCONS platform=android android_arch=x86_64 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86_64-release tools=no target=release_debug
-$SCONS platform=android android_arch=x86_64 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86_64-release tools=no target=release
+  cp /root/mono-glue/*.cpp modules/mono/glue/
+  cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
 
-pushd platform/android/java
-./gradlew generateGodotTemplates
-popd
+  $SCONS platform=android android_arch=armv7 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-armeabi-v7a-release tools=no target=release_debug
+  $SCONS platform=android android_arch=armv7 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-armeabi-v7a-release tools=no target=release
 
-mkdir -p /root/out/templates-mono
-cp bin/android_source.zip /root/out/templates-mono
-cp bin/android_debug.apk /root/out/templates-mono/android_debug.apk
-cp bin/android_release.apk /root/out/templates-mono/android_release.apk
+  $SCONS platform=android android_arch=arm64v8 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-arm64-v8a-release tools=no target=release_debug
+  $SCONS platform=android android_arch=arm64v8 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-arm64-v8a-release tools=no target=release
 
-mkdir /root/out/templates-mono/bcl
-cp -r /root/mono-installs/android-bcl/monodroid /root/out/templates-mono/bcl/
+  $SCONS platform=android android_arch=x86 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86-release tools=no target=release_debug
+  $SCONS platform=android android_arch=x86 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86-release tools=no target=release
+
+  $SCONS platform=android android_arch=x86_64 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86_64-release tools=no target=release_debug
+  $SCONS platform=android android_arch=x86_64 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86_64-release tools=no target=release
+
+  pushd platform/android/java
+  ./gradlew generateGodotTemplates
+  popd
+
+  mkdir -p /root/out/templates-mono
+  cp bin/android_source.zip /root/out/templates-mono
+  cp bin/android_debug.apk /root/out/templates-mono/android_debug.apk
+  cp bin/android_release.apk /root/out/templates-mono/android_release.apk
+
+  mkdir /root/out/templates-mono/bcl
+  cp -r /root/mono-installs/android-bcl/monodroid /root/out/templates-mono/bcl/
+fi
+
+echo "Android build successful"

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -2,10 +2,12 @@
 
 set -e
 
+# Config
+
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export IOS_SDK="12.4"
-export OPTIONS="osxcross_sdk=darwin18 builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes debug_symbols=no use_static_cpp=yes"
+export OPTIONS="osxcross_sdk=darwin18 debug_symbols=no"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 export OSXCROSS_IOS=not_nothing
@@ -15,19 +17,33 @@ mkdir godot
 cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
-$SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release_debug IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
-$SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
+# Classical
 
-$SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release_debug IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
-$SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for iOS..."
 
-/root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot.iphone.opt.arm64.a bin/libgodot.iphone.opt.x86_64.a -output /root/out/libgodot.iphone.opt.fat
-/root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot.iphone.opt.debug.arm64.a bin/libgodot.iphone.opt.debug.x86_64.a -output /root/out/libgodot.iphone.opt.debug.fat
+  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release_debug IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
 
-/root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_arkit_module.iphone.opt.arm64.a bin/libgodot_arkit_module.iphone.opt.x86_64.a -output /root/out/libgodot_arkit_module.iphone.opt.fat
-/root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_arkit_module.iphone.opt.debug.arm64.a bin/libgodot_arkit_module.iphone.opt.debug.x86_64.a -output /root/out/libgodot_arkit_module.iphone.opt.debug.fat
+  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release_debug IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
 
-/root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_camera_module.iphone.opt.arm64.a bin/libgodot_camera_module.iphone.opt.x86_64.a -output /root/out/libgodot_camera_module.iphone.opt.fat
-/root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_camera_module.iphone.opt.debug.arm64.a bin/libgodot_camera_module.iphone.opt.debug.x86_64.a -output /root/out/libgodot_camera_module.iphone.opt.debug.fat
+  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot.iphone.opt.arm64.a bin/libgodot.iphone.opt.x86_64.a -output /root/out/libgodot.iphone.opt.fat
+  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot.iphone.opt.debug.arm64.a bin/libgodot.iphone.opt.debug.x86_64.a -output /root/out/libgodot.iphone.opt.debug.fat
+
+  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_arkit_module.iphone.opt.arm64.a bin/libgodot_arkit_module.iphone.opt.x86_64.a -output /root/out/libgodot_arkit_module.iphone.opt.fat
+  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_arkit_module.iphone.opt.debug.arm64.a bin/libgodot_arkit_module.iphone.opt.debug.x86_64.a -output /root/out/libgodot_arkit_module.iphone.opt.debug.fat
+
+  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_camera_module.iphone.opt.arm64.a bin/libgodot_camera_module.iphone.opt.x86_64.a -output /root/out/libgodot_camera_module.iphone.opt.fat
+  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_camera_module.iphone.opt.debug.arm64.a bin/libgodot_camera_module.iphone.opt.debug.x86_64.a -output /root/out/libgodot_camera_module.iphone.opt.debug.fat
+fi
+
+# Mono
+
+if [ "${MONO}" == "1" ]; then
+  echo "No Mono support for iOS yet."
+  #cp /root/mono-glue/*.cpp modules/mono/glue/
+  #cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+fi
 
 echo "iOS build successful"

--- a/build-javascript/build.sh
+++ b/build-javascript/build.sh
@@ -2,35 +2,49 @@
 
 set -e
 
+# Config
+
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes debug_symbols=no use_static_cpp=yes use_lto=yes"
+export OPTIONS="debug_symbols=no"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release"
 export TERM=xterm
-
-source /root/emsdk/emsdk_env.sh
 
 rm -rf godot
 mkdir godot
 cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
-cp /root/mono-glue/*.cpp modules/mono/glue/
-cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+# Classical
 
-$SCONS platform=javascript ${OPTIONS} target=release_debug tools=no
-$SCONS platform=javascript ${OPTIONS} target=release tools=no
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for JavaScript..."
 
-mkdir -p /root/out/templates
-cp -rvp bin/*.zip /root/out/templates
-rm -f bin/*.zip
+  $SCONS platform=javascript ${OPTIONS} target=release_debug tools=no
+  $SCONS platform=javascript ${OPTIONS} target=release tools=no
 
-$SCONS platform=javascript ${OPTIONS} ${OPTIONS_MONO} target=release_debug tools=no
-$SCONS platform=javascript ${OPTIONS} ${OPTIONS_MONO} target=release tools=no
+  mkdir -p /root/out/templates
+  cp -rvp bin/*.zip /root/out/templates
+  rm -f bin/*.zip
+fi
 
-mkdir -p /root/out/templates-mono
-cp -rvp bin/*.zip /root/out/templates-mono
-rm -f bin/*.zip
+# Mono
 
-mkdir -p /root/out/templates-mono/bcl
-cp -r /root/mono-installs/wasm-bcl/wasm /root/out/templates-mono/bcl/
+if [ "${MONO}" == "1" ]; then
+  echo "Starting Mono build for JavaScript..."
+
+  cp /root/mono-glue/*.cpp modules/mono/glue/
+  cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+
+  $SCONS platform=javascript ${OPTIONS} ${OPTIONS_MONO} target=release_debug tools=no
+  $SCONS platform=javascript ${OPTIONS} ${OPTIONS_MONO} target=release tools=no
+
+  mkdir -p /root/out/templates-mono
+  cp -rvp bin/*.zip /root/out/templates-mono
+  rm -f bin/*.zip
+
+  mkdir -p /root/out/templates-mono/bcl
+  cp -r /root/mono-installs/wasm-bcl/wasm /root/out/templates-mono/bcl/
+fi
+
+echo "JavaScript build successful"

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+# Config
+
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes debug_symbols=no use_static_cpp=yes use_lto=yes"
+export OPTIONS="debug_symbols=no use_static_cpp=yes use_lto=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 export CC="gcc-8"
@@ -15,30 +17,42 @@ mkdir godot
 cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
-cp /root/mono-glue/*.cpp modules/mono/glue/
-cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+# Classical
 
-$SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS tools=yes target=release_debug
-mkdir -p /root/out/tools
-cp -rvp bin/* /root/out/tools
-rm -rf bin
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for Linux..."
 
-$SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS tools=no target=release_debug
-$SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS tools=no target=release
-mkdir -p /root/out/templates
-cp -rvp bin/* /root/out/templates
-rm -rf bin
+  $SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS tools=yes target=release_debug
+  mkdir -p /root/out/tools
+  cp -rvp bin/* /root/out/tools
+  rm -rf bin
 
-export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
+  $SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS tools=no target=release_debug
+  $SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS tools=no target=release
+  mkdir -p /root/out/templates
+  cp -rvp bin/* /root/out/templates
+  rm -rf bin
+fi
 
-$SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
-mkdir -p /root/out/tools-mono
-cp -rvp bin/* /root/out/tools-mono
-rm -rf bin
+# Mono
 
-$SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release_debug
-$SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release
-mkdir -p /root/out/templates-mono
-cp -rvp bin/* /root/out/templates-mono
-rm -rf bin
+if [ "${MONO}" == "1" ]; then
+  echo "Starting Mono build for Linux..."
 
+  cp /root/mono-glue/*.cpp modules/mono/glue/
+  cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+  export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
+
+  $SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
+  mkdir -p /root/out/tools-mono
+  cp -rvp bin/* /root/out/tools-mono
+  rm -rf bin
+
+  $SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release
+  mkdir -p /root/out/templates-mono
+  cp -rvp bin/* /root/out/templates-mono
+  rm -rf bin
+fi
+
+echo "Linux build successful"

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+# Config
+
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes debug_symbols=no"
+export OPTIONS="debug_symbols=no"
 export TERM=xterm
 
 rm -rf godot
@@ -12,10 +14,18 @@ mkdir godot
 cd godot
 tar xf ../godot.tar.gz --strip-components=1
 
-mono --version
-export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
+# Mono
 
-${SCONS} platform=x11 bits=64 ${OPTIONS} target=release_debug tools=yes module_mono_enabled=yes mono_glue=no
+if [ "${MONO}" == "1" ]; then
+  echo "Building and generating Mono glue..."
 
-rm -rf /root/mono-glue/*
-xvfb-run bin/godot.x11.opt.tools.64.mono --generate-mono-glue /root/mono-glue || /bin/true
+  mono --version
+  export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
+
+  ${SCONS} platform=x11 bits=64 ${OPTIONS} target=release_debug tools=yes module_mono_enabled=yes mono_glue=no
+
+  rm -rf /root/mono-glue/*
+  xvfb-run bin/godot.x11.opt.tools.64.mono --generate-mono-glue /root/mono-glue || /bin/true
+fi
+
+echo "Mono glue generated successfully"

--- a/build-release.sh
+++ b/build-release.sh
@@ -2,12 +2,7 @@
 
 set -e
 
-if [ -z $1 ]; then
-  echo "Usage: $0 <version>"
-  echo "  For example: $0 3.0.3-rc3"
-  echo ""
-  exit 1
-fi
+# Config
 
 # For signing keystore and password.
 source ./config.sh
@@ -27,332 +22,358 @@ function sign {
   mv $1-signed $1
 }
 
-export GODOT_VERSION=$1
+godot_version=""
+build_classical=1
+build_mono=1
+
+while getopts "h?v:b" opt; do
+  case "$opt" in
+  h|\?)
+    echo "Usage: $0 [OPTIONS...]"
+    echo
+    echo "  -v godot version (e.g: 3.1-alpha5) [mandatory]"
+    echo "  -b all|classical|mono (default: all)"
+    echo
+    exit 1
+    ;;
+  v)
+    godot_version=$OPTARG
+    ;;
+  b)
+    if [ "$OPTARG" == "classical" ]; then
+      build_mono=0
+    elif [ "$OPTARG" == "mono" ]; then
+      build_classical=0
+    fi
+    ;;
+  esac
+done
+
+export basedir=$(pwd)
+export reldir="${basedir}/releases/${godot_version}"
+export reldir_mono="${reldir}/mono"
+export tmpdir="${basedir}/tmp"
+export templatesdir="${tmpdir}/templates"
+export templatesdir_mono="${templatesdir}-mono"
+
+export godot_basename="Godot_v${godot_version}"
+
+# Cleanup and setup
+
+rm -rf ${reldir}
+rm -rf ${tmpdir}
+
+mkdir -p ${reldir}
+mkdir -p ${reldir_mono}
+mkdir -p ${templatesdir}
+mkdir -p ${templatesdir_mono}
 
 # Tarball
 
-mkdir -p release-${GODOT_VERSION}
-rm -rf release-${GODOT_VERSION}/*.xz release-${GODOT_VERSION}/*.sha256
-zcat godot.tar.gz | xz -c > release-${GODOT_VERSION}/godot-${GODOT_VERSION}.tar.xz
-sha256sum release-${GODOT_VERSION}/godot-${GODOT_VERSION}.tar.xz > release-${GODOT_VERSION}/godot-${GODOT_VERSION}.tar.xz.sha256
+zcat godot.tar.gz | xz -c > ${reldir}/godot-${godot_version}.tar.xz
+pushd ${reldir}
+sha256sum godot-${godot_version}.tar.xz > godot-${godot_version}.tar.xz.sha256
+popd
+
+# Classical
+
+if [ "${build_classical}" == "1" ]; then
+
+  ## Linux (Classical) ##
+
+  # Editor
+  binname="${godot_basename}_x11.64"
+  cp out/linux/x64/tools/godot.x11.opt.tools.64 ${binname}
+  zip -q -9 "${reldir}/${binname}.zip" ${binname}
+  rm ${binname}
+
+  binname="${godot_basename}_x11.32"
+  cp out/linux/x86/tools/godot.x11.opt.tools.32 ${binname}
+  zip -q -9 "${reldir}/${binname}.zip" ${binname}
+  rm ${binname}
+
+  # Templates
+  cp out/linux/x64/templates/godot.x11.opt.64 ${templatesdir}/linux_x11_64_release
+  cp out/linux/x64/templates/godot.x11.opt.debug.64 ${templatesdir}/linux_x11_64_debug
+  cp out/linux/x86/templates/godot.x11.opt.32 ${templatesdir}/linux_x11_32_release
+  cp out/linux/x86/templates/godot.x11.opt.debug.32 ${templatesdir}/linux_x11_32_debug
+
+  ## Windows (Classical) ##
+
+  # Editor
+  binname="${godot_basename}_win64.exe"
+  cp out/windows/x64/tools/godot.windows.opt.tools.64.exe ${binname}
+  strip ${binname}
+  sign ${binname}
+  zip -q -9 "${reldir}/${binname}.zip" ${binname}
+  rm ${binname}
+
+  binname="${godot_basename}_win32.exe"
+  cp out/windows/x86/tools/godot.windows.opt.tools.32.exe ${binname}
+  strip ${binname}
+  sign ${binname}
+  zip -q -9 "${reldir}/${binname}.zip" ${binname}
+  rm ${binname}
+
+  # Templates
+  cp out/windows/x64/templates/godot.windows.opt.64.exe ${templatesdir}/windows_64_release.exe
+  cp out/windows/x64/templates/godot.windows.opt.debug.64.exe ${templatesdir}/windows_64_debug.exe
+  cp out/windows/x86/templates/godot.windows.opt.32.exe ${templatesdir}/windows_32_release.exe
+  cp out/windows/x86/templates/godot.windows.opt.debug.32.exe ${templatesdir}/windows_32_debug.exe
+
+  strip ${templatesdir}/windows*.exe
+
+  sign ${templatesdir}/windows_64_release.exe
+  sign ${templatesdir}/windows_64_debug.exe
+  sign ${templatesdir}/windows_32_release.exe
+  sign ${templatesdir}/windows_32_debug.exe
+
+  ## OSX (Classical) ##
+
+  # Editor
+  binname="${godot_basename}_osx.64"
+  rm -rf Godot.app
+  cp -r git/misc/dist/osx_tools.app Godot.app
+  mkdir -p Godot.app/Contents/MacOS
+  cp out/macosx/x64/tools/godot.osx.opt.tools.64 Godot.app/Contents/MacOS/Godot
+  chmod +x Godot.app/Contents/MacOS/Godot
+  zip -q -9 -r "${reldir}/${binname}.zip" Godot.app
+  rm -rf Godot.app
+
+  # Templates
+  rm -rf osx_template.app
+  cp -r git/misc/dist/osx_template.app .
+  mkdir -p osx_template.app/Contents/MacOS
+
+  cp out/macosx/x64/templates/godot.osx.opt.64 osx_template.app/Contents/MacOS/godot_osx_release.64
+  cp out/macosx/x64/templates/godot.osx.opt.debug.64 osx_template.app/Contents/MacOS/godot_osx_debug.64
+  chmod +x osx_template.app/Contents/MacOS/godot_osx*
+  zip -q -9 -r "${templatesdir}/osx.zip" osx_template.app
+  rm -rf osx_template.app
+
+  ## Server (Classical) ##
+
+  # Headless (editor)
+  binname="${godot_basename}_linux_headless.64"
+  cp out/server/x64/tools/godot_server.x11.opt.tools.64 ${binname}
+  zip -q -9 "${reldir}/${binname}.zip" ${binname}
+  rm ${binname}
+
+  # Server (template)
+  binname="${godot_basename}_linux_server.64"
+  cp out/server/x64/templates/godot_server.x11.opt.64 ${binname}
+  zip -q -9 "${reldir}/${binname}.zip" ${binname}
+  rm ${binname}
+
+  ## Javascript (Classical) ##
+
+  # Templates
+  cp out/javascript/templates/godot.javascript.opt.zip ${templatesdir}/webassembly_release.zip
+  cp out/javascript/templates/godot.javascript.opt.debug.zip ${templatesdir}/webassembly_debug.zip
+
+  ## Android (Classical) ##
+
+  # Templates
+  cp out/android/templates/*.apk ${templatesdir}/
+  cp out/android/templates/android_source.zip ${templatesdir}/
+
+  ## iOS (Classical) ##
+
+  rm -rf ios_xcode
+  cp -r git/misc/dist/ios_xcode ios_xcode
+  for suffix in "" "_arkit_module" "_camera_module"; do
+    cp out/ios/libgodot${suffix}.iphone.opt.fat ios_xcode/libgodot${suffix}.iphone.release.fat.a
+    cp out/ios/libgodot${suffix}.iphone.opt.debug.fat ios_xcode/libgodot${suffix}.iphone.debug.fat.a
+  done
+  chmod +x ios_xcode/libgodot*.iphone.*
+  cd ios_xcode
+  zip -q -9 -r "${templatesdir}/iphone.zip" *
+  cd ..
+  rm -rf ios_xcode
+
+  ## UWP (Classical) ##
+
+  if [ ! -d "angle" ]; then
+    echo "Downloading ANGLE binaries from https://github.com/GodotBuilder/godot-builds/releases/tag/_tools"
+    curl -LO https://github.com/GodotBuilder/godot-builds/releases/download/_tools/angle.7z
+    7z x angle.7z && rm -f angle.7z
+  fi
+
+  rm -rf uwp_template_*
+  for arch in ARM Win32 x64; do
+    cp -r git/misc/dist/uwp_template uwp_template_${arch}
+    cp angle/winrt/10/src/Release_${arch}/libEGL.dll \
+      angle/winrt/10/src/Release_${arch}/libGLESv2.dll \
+      uwp_template_${arch}/
+    cp -r uwp_template_${arch} uwp_template_${arch}_debug
+  done
+
+  cp out/uwp/arm/godot.uwp.opt.32.arm.exe uwp_template_ARM/godot.uwp.exe
+  cp out/uwp/arm/godot.uwp.opt.debug.32.arm.exe uwp_template_ARM_debug/godot.uwp.exe
+  sign uwp_template_ARM/godot.uwp.exe
+  sign uwp_template_ARM_debug/godot.uwp.exe
+  cd uwp_template_ARM && zip -q -9 -r "${templatesdir}/uwp_arm_release.zip" * && cd ..
+  cd uwp_template_ARM_debug && zip -q -9 -r "${templatesdir}/uwp_arm_debug.zip" * && cd ..
+  rm -rf uwp_template_ARM*
+
+  cp out/uwp/x86/godot.uwp.opt.32.x86.exe uwp_template_Win32/godot.uwp.exe
+  cp out/uwp/x86/godot.uwp.opt.debug.32.x86.exe uwp_template_Win32_debug/godot.uwp.exe
+  sign uwp_template_Win32/godot.uwp.exe
+  sign uwp_template_Win32_debug/godot.uwp.exe
+  cd uwp_template_Win32 && zip -q -9 -r "${templatesdir}/uwp_x86_release.zip" * && cd ..
+  cd uwp_template_Win32_debug && zip -q -9 -r "${templatesdir}/uwp_x86_debug.zip" * && cd ..
+  rm -rf uwp_template_Win32*
+
+  cp out/uwp/x64/godot.uwp.opt.64.x64.exe uwp_template_x64/godot.uwp.exe
+  cp out/uwp/x64/godot.uwp.opt.debug.64.x64.exe uwp_template_x64_debug/godot.uwp.exe
+  sign uwp_template_x64/godot.uwp.exe
+  sign uwp_template_x64_debug/godot.uwp.exe
+  cd uwp_template_x64 && zip -q -9 -r "${templatesdir}/uwp_x64_release.zip" * && cd ..
+  cd uwp_template_x64_debug && zip -q -9 -r "${templatesdir}/uwp_x64_debug.zip" * && cd ..
+  rm -rf uwp_template_x64*
 
-# Linux 64
-
-mkdir -p templates
-rm -f templates/linux_x11_64*
-
-cp out/linux/x64/templates/godot.x11.opt.debug.64 templates/linux_x11_64_debug
-cp out/linux/x64/templates/godot.x11.opt.64 templates/linux_x11_64_release
-
-mkdir -p release-${GODOT_VERSION}
-rm -f release-${GODOT_VERSION}/*linux*64*
-
-cp out/linux/x64/tools/godot.x11.opt.tools.64 Godot_v${GODOT_VERSION}_x11.64
-zip -q -9 Godot_v${GODOT_VERSION}_x11.64.zip Godot_v${GODOT_VERSION}_x11.64
-mv Godot_v${GODOT_VERSION}_x11.64.zip release-${GODOT_VERSION}
-rm Godot_v${GODOT_VERSION}_x11.64
-
-mkdir -p mono/release-${GODOT_VERSION}
-rm -rf mono/release-${GODOT_VERSION}/*linux*64*
-
-mkdir -p Godot_v${GODOT_VERSION}_mono_x11_64
-cp out/linux/x64/tools-mono/godot.x11.opt.tools.64.mono Godot_v${GODOT_VERSION}_mono_x11_64/Godot_v${GODOT_VERSION}_mono_x11.64
-cp -rp out/linux/x64/tools-mono/GodotSharp Godot_v${GODOT_VERSION}_mono_x11_64
-zip -r -q -9 Godot_v${GODOT_VERSION}_mono_x11_64.zip Godot_v${GODOT_VERSION}_mono_x11_64
-mv Godot_v${GODOT_VERSION}_mono_x11_64.zip mono/release-${GODOT_VERSION}
-rm -rf Godot_v${GODOT_VERSION}_mono_x11_64
-
-mkdir -p mono/templates
-rm -rf mono/templates/*linux*64*
-
-cp -rp out/linux/x64/templates-mono/data.mono.x11.64.* mono/templates/
-cp out/linux/x64/templates-mono/godot.x11.opt.debug.64.mono mono/templates/linux_x11_64_debug
-cp out/linux/x64/templates-mono/godot.x11.opt.64.mono mono/templates/linux_x11_64_release
-
-# Linux 32
-
-mkdir -p templates
-rm -f templates/linux_x11_32*
-
-cp out/linux/x86/templates/godot.x11.opt.debug.32 templates/linux_x11_32_debug
-cp out/linux/x86/templates/godot.x11.opt.32 templates/linux_x11_32_release
-
-mkdir -p release-${GODOT_VERSION}
-rm -f release-${GODOT_VERSION}/*linux*32*
-
-cp out/linux/x86/tools/godot.x11.opt.tools.32 Godot_v${GODOT_VERSION}_x11.32
-zip -q -9 Godot_v${GODOT_VERSION}_x11.32.zip Godot_v${GODOT_VERSION}_x11.32
-mv Godot_v${GODOT_VERSION}_x11.32.zip release-${GODOT_VERSION}
-rm Godot_v${GODOT_VERSION}_x11.32
-
-mkdir -p mono/release-${GODOT_VERSION}
-rm -rf mono/release-${GODOT_VERSION}/*linux*32*
-
-mkdir -p Godot_v${GODOT_VERSION}_mono_x11_32
-cp out/linux/x86/tools-mono/godot.x11.opt.tools.32.mono Godot_v${GODOT_VERSION}_mono_x11_32/Godot_v${GODOT_VERSION}_mono_x11.32
-cp -rp out/linux/x86/tools-mono/GodotSharp/ Godot_v${GODOT_VERSION}_mono_x11_32
-zip -r -q -9 Godot_v${GODOT_VERSION}_mono_x11_32.zip Godot_v${GODOT_VERSION}_mono_x11_32
-mv Godot_v${GODOT_VERSION}_mono_x11_32.zip mono/release-${GODOT_VERSION}
-rm -rf Godot_v${GODOT_VERSION}_mono_x11_32
-
-mkdir -p mono/templates
-rm -rf mono/templates/*linux*32*
-
-cp -rp out/linux/x86/templates-mono/data.mono.x11.32.* mono/templates/
-cp out/linux/x86/templates-mono/godot.x11.opt.debug.32.mono mono/templates/linux_x11_32_debug
-cp out/linux/x86/templates-mono/godot.x11.opt.32.mono mono/templates/linux_x11_32_release
-
-# Windows
-
-mkdir -p release-${GODOT_VERSION}
-rm -f release-${GODOT_VERSION}/*win*zip
-
-cp out/windows/x64/tools/godot.windows.opt.tools.64.exe Godot_v${GODOT_VERSION}_win64.exe
-strip Godot_v${GODOT_VERSION}_win64.exe
-sign Godot_v${GODOT_VERSION}_win64.exe
-zip -q -9 Godot_v${GODOT_VERSION}_win64.exe.zip Godot_v${GODOT_VERSION}_win64.exe
-mv Godot_v${GODOT_VERSION}_win64.exe.zip release-${GODOT_VERSION}
-rm Godot_v${GODOT_VERSION}_win64.exe
-
-cp out/windows/x86/tools/godot.windows.opt.tools.32.exe Godot_v${GODOT_VERSION}_win32.exe
-strip Godot_v${GODOT_VERSION}_win32.exe
-sign Godot_v${GODOT_VERSION}_win32.exe
-zip -q -9 Godot_v${GODOT_VERSION}_win32.exe.zip Godot_v${GODOT_VERSION}_win32.exe
-mv Godot_v${GODOT_VERSION}_win32.exe.zip release-${GODOT_VERSION}
-rm Godot_v${GODOT_VERSION}_win32.exe
-
-mkdir -p templates
-rm -rf templates/*win*
-
-cp out/windows/x64/templates/godot.windows.opt.64.exe templates/windows_64_release.exe
-cp out/windows/x64/templates/godot.windows.opt.debug.64.exe templates/windows_64_debug.exe
-cp out/windows/x86/templates/godot.windows.opt.32.exe templates/windows_32_release.exe
-cp out/windows/x86/templates/godot.windows.opt.debug.32.exe templates/windows_32_debug.exe
-
-strip templates/windows*.exe
-
-sign templates/windows_64_release.exe
-sign templates/windows_64_debug.exe
-sign templates/windows_32_release.exe
-sign templates/windows_32_debug.exe
-
-mkdir -p mono/release-${GODOT_VERSION}
-rm -rf mono/release-${GODOT_VERSION}/*win*
-
-mkdir -p mono/templates
-rm -rf mono/templates/*win*
-
-mkdir -p Godot_v${GODOT_VERSION}_mono_win64
-cp out/windows/x64/tools-mono/godot.windows.opt.tools.64.mono.exe Godot_v${GODOT_VERSION}_mono_win64/Godot_v${GODOT_VERSION}_mono_win64.exe
-strip Godot_v${GODOT_VERSION}_mono_win64/Godot_v${GODOT_VERSION}_mono_win64.exe
-sign Godot_v${GODOT_VERSION}_mono_win64/Godot_v${GODOT_VERSION}_mono_win64.exe
-cp -rp out/windows/x64/tools-mono/GodotSharp Godot_v${GODOT_VERSION}_mono_win64
-zip -r -q -9 Godot_v${GODOT_VERSION}_mono_win64.zip Godot_v${GODOT_VERSION}_mono_win64
-mv Godot_v${GODOT_VERSION}_mono_win64.zip mono/release-${GODOT_VERSION}
-rm -rf Godot_v${GODOT_VERSION}_mono_win64
-
-cp -rp out/windows/x64/templates-mono/data.mono.windows.64.* mono/templates/
-cp out/windows/x64/templates-mono/godot.windows.opt.debug.64.mono.exe mono/templates/windows_64_debug.exe
-cp out/windows/x64/templates-mono/godot.windows.opt.64.mono.exe mono/templates/windows_64_release.exe
-
-mkdir -p Godot_v${GODOT_VERSION}_mono_win32
-cp out/windows/x86/tools-mono/godot.windows.opt.tools.32.mono.exe Godot_v${GODOT_VERSION}_mono_win32/Godot_v${GODOT_VERSION}_mono_win32.exe
-strip Godot_v${GODOT_VERSION}_mono_win32/Godot_v${GODOT_VERSION}_mono_win32.exe
-sign Godot_v${GODOT_VERSION}_mono_win32/Godot_v${GODOT_VERSION}_mono_win32.exe
-cp -rp  out/windows/x86/tools-mono/GodotSharp Godot_v${GODOT_VERSION}_mono_win32
-zip -r -q -9 Godot_v${GODOT_VERSION}_mono_win32.zip Godot_v${GODOT_VERSION}_mono_win32
-mv Godot_v${GODOT_VERSION}_mono_win32.zip mono/release-${GODOT_VERSION}
-rm -rf Godot_v${GODOT_VERSION}_mono_win32
-
-cp -rp out/windows/x86/templates-mono/data.mono.windows.32.* mono/templates/
-cp out/windows/x86/templates-mono/godot.windows.opt.debug.32.mono.exe mono/templates/windows_32_debug.exe
-cp out/windows/x86/templates-mono/godot.windows.opt.32.mono.exe mono/templates/windows_32_release.exe
-
-strip mono/templates/windows*.exe
-
-sign mono/templates/windows_64_debug.exe
-sign mono/templates/windows_64_release.exe
-sign mono/templates/windows_32_debug.exe
-sign mono/templates/windows_32_release.exe
-
-# OSX
-
-mkdir -p templates
-rm -f templates/osx*
-
-rm -rf osx_template
-mkdir -p osx_template
-cd osx_template
-
-cp -r ../git/misc/dist/osx_template.app .
-mkdir osx_template.app/Contents/MacOS
-
-cp ../out/macosx/x64/templates/godot.osx.opt.64 osx_template.app/Contents/MacOS/godot_osx_release.64
-cp ../out/macosx/x64/templates/godot.osx.opt.debug.64 osx_template.app/Contents/MacOS/godot_osx_debug.64
-chmod +x osx_template.app/Contents/MacOS/godot_osx*
-zip -q -9 -r osx.zip osx_template.app
-cd ..
-
-mv osx_template/osx.zip templates
-rm -rf osx_template
-
-mkdir -p release-${GODOT_VERSION}
-rm -f release-${GODOT_VERSION}/*osx*
-
-cp -r git/misc/dist/osx_tools.app Godot.app
-mkdir -p Godot.app/Contents/MacOS
-cp out/macosx/x64/tools/godot.osx.opt.tools.64 Godot.app/Contents/MacOS/Godot
-chmod +x Godot.app/Contents/MacOS/Godot
-zip -q -9 -r "release-${GODOT_VERSION}/Godot_v${GODOT_VERSION}_osx.64.zip" Godot.app
-rm -rf Godot.app
-
-mkdir -p mono/templates
-rm -rf mono/templates/osx*
-
-rm -rf osx_template
-mkdir -p osx_template
-cd osx_template
-
-cp -r ../git/misc/dist/osx_template.app .
-mkdir osx_template.app/Contents/MacOS
-
-cp ../out/macosx/x64/templates-mono/godot.osx.opt.64.mono osx_template.app/Contents/MacOS/godot_osx_release.64
-cp ../out/macosx/x64/templates-mono/godot.osx.opt.debug.64.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
-cp -rp ../out/macosx/x64/templates-mono/data.mono.osx.64.* osx_template.app/Contents/MacOS/
-chmod +x osx_template.app/Contents/MacOS/godot_osx*
-zip -q -9 -r osx.zip osx_template.app
-cd ..
-
-mv osx_template/osx.zip mono/templates
-rm -rf osx_template
-
-mkdir -p mono/release-${GODOT_VERSION}
-rm -f mono/release-${GODOT_VERSION}/*osx*
-
-cp -r git/misc/dist/osx_tools.app Godot_mono.app
-mkdir -p Godot_mono.app/Contents/MacOS
-cp out/macosx/x64/tools-mono/godot.osx.opt.tools.64.mono Godot_mono.app/Contents/MacOS/Godot
-mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}
-mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp
-mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp/Mono
-cp -rp out/macosx/x64/tools-mono/GodotSharp/Api Godot_mono.app/Contents/Frameworks/GodotSharp
-cp -rp out/macosx/x64/tools-mono/GodotSharp/Mono/lib Godot_mono.app/Contents/Frameworks/GodotSharp/Mono
-cp -rp out/macosx/x64/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
-cp -rp out/macosx/x64/tools-mono/GodotSharp/Mono/etc Godot_mono.app/Contents/Resources/GodotSharp/Mono
-chmod +x Godot_mono.app/Contents/MacOS/Godot
-zip -q -9 -r "mono/release-${GODOT_VERSION}/Godot_v${GODOT_VERSION}_mono_osx.64.zip" Godot_mono.app
-rm -rf Godot_mono.app
-
-# Server
-
-cp out/server/x64/templates/godot_server.x11.opt.64 Godot_v${GODOT_VERSION}_linux_server.64
-zip -q -9 Godot_v${GODOT_VERSION}_linux_server.64.zip Godot_v${GODOT_VERSION}_linux_server.64
-mv Godot_v${GODOT_VERSION}_linux_server.64.zip release-${GODOT_VERSION}
-rm Godot_v${GODOT_VERSION}_linux_server.64
-
-cp out/server/x64/tools/godot_server.x11.opt.tools.64 Godot_v${GODOT_VERSION}_linux_headless.64
-zip -q -9 Godot_v${GODOT_VERSION}_linux_headless.64.zip Godot_v${GODOT_VERSION}_linux_headless.64
-mv Godot_v${GODOT_VERSION}_linux_headless.64.zip release-${GODOT_VERSION}
-rm Godot_v${GODOT_VERSION}_linux_headless.64
-
-mkdir -p Godot_v${GODOT_VERSION}_mono_linux_server_64
-cp out/server/x64/templates/godot_server.x11.opt.64.mono Godot_v${GODOT_VERSION}_mono_linux_server_64/Godot_v${GODOT_VERSION}_mono_linux_server.64
-cp -rp out/server/x64/templates/data.mono.server.64.release Godot_v${GODOT_VERSION}_mono_linux_server_64/data_Godot_v${GODOT_VERSION}_mono_linux_server
-zip -r -q -9 Godot_v${GODOT_VERSION}_mono_linux_server_64.zip Godot_v${GODOT_VERSION}_mono_linux_server_64
-mv Godot_v${GODOT_VERSION}_mono_linux_server_64.zip mono/release-${GODOT_VERSION}
-rm -rf Godot_v${GODOT_VERSION}_mono_linux_server_64
-
-mkdir -p Godot_v${GODOT_VERSION}_mono_linux_headless_64
-cp out/server/x64/tools/godot_server.x11.opt.tools.64.mono Godot_v${GODOT_VERSION}_mono_linux_headless_64/Godot_v${GODOT_VERSION}_mono_linux_headless.64
-cp -rp out/server/x64/tools/GodotSharp Godot_v${GODOT_VERSION}_mono_linux_headless_64
-zip -r -q -9 Godot_v${GODOT_VERSION}_mono_linux_headless_64.zip Godot_v${GODOT_VERSION}_mono_linux_headless_64
-mv Godot_v${GODOT_VERSION}_mono_linux_headless_64.zip mono/release-${GODOT_VERSION}
-rm -rf Godot_v${GODOT_VERSION}_mono_linux_headless_64
-
-# Javascript
-
-cp out/javascript/templates/godot.javascript.opt.zip templates/webassembly_release.zip
-cp out/javascript/templates/godot.javascript.opt.debug.zip templates/webassembly_debug.zip
-
-mkdir -p mono/templates
-
-cp out/javascript/templates-mono/godot.javascript.opt.mono.zip mono/templates/webassembly_release.zip
-cp out/javascript/templates-mono/godot.javascript.opt.debug.mono.zip mono/templates/webassembly_debug.zip
-
-mkdir -p mono/templates/bcl
-cp -r out/javascript/templates-mono/bcl/wasm mono/templates/bcl/
-
-# Android
-
-cp out/android/templates/*.apk templates
-cp out/android/templates/android_source.zip templates
-
-cp out/android/templates-mono/*.apk mono/templates
-cp out/android/templates-mono/android_source.zip mono/templates
-
-mkdir -p mono/templates/bcl
-cp -r out/android/templates-mono/bcl/monodroid mono/templates/bcl/
-
-# iOS
-
-cp -r git/misc/dist/ios_xcode ios_xcode
-cp out/ios/libgodot.iphone.opt.fat ios_xcode/libgodot.iphone.release.fat.a
-cp out/ios/libgodot.iphone.opt.debug.fat ios_xcode/libgodot.iphone.debug.fat.a
-
-cp out/ios/libgodot_arkit_module.iphone.opt.fat ios_xcode/libgodot_arkit_module.iphone.release.fat.a
-cp out/ios/libgodot_arkit_module.iphone.opt.debug.fat ios_xcode/libgodot_arkit_module.iphone.debug.fat.a
-
-cp out/ios/libgodot_camera_module.iphone.opt.fat ios_xcode/libgodot_camera_module.iphone.release.fat.a
-cp out/ios/libgodot_camera_module.iphone.opt.debug.fat ios_xcode/libgodot_camera_module.iphone.debug.fat.a
-
-chmod +x ios_xcode/libgodot*.iphone.*
-cd ios_xcode
-zip -q -9 -r ../templates/iphone.zip *
-cd ..
-rm -rf ios_xcode
-
-# UWP
-
-if [ ! -d "angle" ]; then
-  echo "Downloading ANGLE binaries from https://github.com/GodotBuilder/godot-builds/releases/tag/_tools"
-  curl -LO https://github.com/GodotBuilder/godot-builds/releases/download/_tools/angle.7z
-  7z x angle.7z && rm -f angle.7z
 fi
 
-mkdir -p templates
-rm -f templates/uwp*
-rm -rf uwp_template_*
+# Mono
 
-for arch in ARM Win32 x64; do
-  cp -r git/misc/dist/uwp_template uwp_template_${arch}
+if [ "${build_mono}" == "1" ]; then
 
-  cp angle/winrt/10/src/Release_${arch}/libEGL.dll \
-     angle/winrt/10/src/Release_${arch}/libGLESv2.dll \
-     uwp_template_${arch}/
-  cp -r uwp_template_${arch} uwp_template_${arch}_debug
-done
+  ## Linux (Mono) ##
 
-cp out/uwp/arm/godot.uwp.opt.32.arm.exe uwp_template_ARM/godot.uwp.exe
-cp out/uwp/arm/godot.uwp.opt.debug.32.arm.exe uwp_template_ARM_debug/godot.uwp.exe
-sign uwp_template_ARM/godot.uwp.exe
-sign uwp_template_ARM_debug/godot.uwp.exe
-cd uwp_template_ARM && zip -q -9 -r ../templates/uwp_arm_release.zip * && cd ..
-cd uwp_template_ARM_debug && zip -q -9 -r ../templates/uwp_arm_debug.zip * && cd ..
+  # Editor
+  binbasename="${godot_basename}_mono_x11"
+  mkdir -p ${binbasename}_64
+  cp out/linux/x64/tools-mono/godot.x11.opt.tools.64.mono ${binbasename}_64/${binbasename}.64
+  cp -rp out/linux/x64/tools-mono/GodotSharp ${binbasename}_64/
+  zip -r -q -9 "${reldir_mono}/${binbasename}_64.zip" ${binbasename}_64
+  rm -rf ${binbasename}_64
 
-cp out/uwp/x86/godot.uwp.opt.32.x86.exe uwp_template_Win32/godot.uwp.exe
-cp out/uwp/x86/godot.uwp.opt.debug.32.x86.exe uwp_template_Win32_debug/godot.uwp.exe
-sign uwp_template_Win32/godot.uwp.exe
-sign uwp_template_Win32_debug/godot.uwp.exe
-cd uwp_template_Win32 && zip -q -9 -r ../templates/uwp_x86_release.zip * && cd ..
-cd uwp_template_Win32_debug && zip -q -9 -r ../templates/uwp_x86_debug.zip * && cd ..
+  binbasename="${godot_basename}_mono_x11"
+  mkdir -p ${binbasename}_32
+  cp out/linux/x86/tools-mono/godot.x11.opt.tools.32.mono ${binbasename}_32/${binbasename}.32
+  cp -rp out/linux/x86/tools-mono/GodotSharp/ ${binbasename}_32/
+  zip -r -q -9 "${reldir_mono}/${binbasename}_32.zip" ${binbasename}_32
+  rm -rf ${binbasename}_32
 
-cp out/uwp/x64/godot.uwp.opt.64.x64.exe uwp_template_x64/godot.uwp.exe
-cp out/uwp/x64/godot.uwp.opt.debug.64.x64.exe uwp_template_x64_debug/godot.uwp.exe
-sign uwp_template_x64/godot.uwp.exe
-sign uwp_template_x64_debug/godot.uwp.exe
-cd uwp_template_x64 && zip -q -9 -r ../templates/uwp_x64_release.zip * && cd ..
-cd uwp_template_x64_debug && zip -q -9 -r ../templates/uwp_x64_debug.zip * && cd ..
+  # Templates
+  cp -rp out/linux/x64/templates-mono/data.mono.x11.64.* ${templatesdir_mono}/
+  cp out/linux/x64/templates-mono/godot.x11.opt.debug.64.mono ${templatesdir_mono}/linux_x11_64_debug
+  cp out/linux/x64/templates-mono/godot.x11.opt.64.mono ${templatesdir_mono}/linux_x11_64_release
+  cp -rp out/linux/x86/templates-mono/data.mono.x11.32.* ${templatesdir_mono}/
+  cp out/linux/x86/templates-mono/godot.x11.opt.debug.32.mono ${templatesdir_mono}/linux_x11_32_debug
+  cp out/linux/x86/templates-mono/godot.x11.opt.32.mono ${templatesdir_mono}/linux_x11_32_release
 
-rm -rf uwp_template_*
+  ## Windows (Mono) ##
 
-exit 0
+  # Editor
+  binname="${godot_basename}_mono_win64"
+  mkdir -p ${binname}
+  cp out/windows/x64/tools-mono/godot.windows.opt.tools.64.mono.exe ${binname}/${binname}.exe
+  strip ${binname}/${binname}.exe
+  sign ${binname}/${binname}.exe
+  cp -rp out/windows/x64/tools-mono/GodotSharp ${binname}/
+  zip -r -q -9 "${reldir_mono}/${binname}.zip" ${binname}
+  rm -rf ${binname}
+
+  binname="${godot_basename}_mono_win32"
+  mkdir -p ${binname}
+  cp out/windows/x86/tools-mono/godot.windows.opt.tools.32.mono.exe ${binname}/${binname}.exe
+  strip ${binname}/${binname}.exe
+  sign ${binname}/${binname}.exe
+  cp -rp out/windows/x86/tools-mono/GodotSharp ${binname}/
+  zip -r -q -9 "${reldir_mono}/${binname}.zip" ${binname}
+  rm -rf ${binname}
+
+  # Templates
+  cp -rp out/windows/x64/templates-mono/data.mono.windows.64.* ${templatesdir_mono}/
+  cp out/windows/x64/templates-mono/godot.windows.opt.debug.64.mono.exe ${templatesdir_mono}/windows_64_debug.exe
+  cp out/windows/x64/templates-mono/godot.windows.opt.64.mono.exe ${templatesdir_mono}/windows_64_release.exe
+  cp -rp out/windows/x86/templates-mono/data.mono.windows.32.* ${templatesdir_mono}/
+  cp out/windows/x86/templates-mono/godot.windows.opt.debug.32.mono.exe ${templatesdir_mono}/windows_32_debug.exe
+  cp out/windows/x86/templates-mono/godot.windows.opt.32.mono.exe ${templatesdir_mono}/windows_32_release.exe
+
+  strip ${templatesdir_mono}/windows*.exe
+
+  sign ${templatesdir_mono}/windows_64_debug.exe
+  sign ${templatesdir_mono}/windows_64_release.exe
+  sign ${templatesdir_mono}/windows_32_debug.exe
+  sign ${templatesdir_mono}/windows_32_release.exe
+
+  ## OSX (Mono) ##
+
+  # Editor
+  binname="${godot_basename}_mono_osx.64"
+  rm -rf Godot_mono.app
+  cp -r git/misc/dist/osx_tools.app Godot_mono.app
+  mkdir -p Godot_mono.app/Contents/MacOS
+  cp out/macosx/x64/tools-mono/godot.osx.opt.tools.64.mono Godot_mono.app/Contents/MacOS/Godot
+  mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}
+  mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp
+  mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp/Mono
+  cp -rp out/macosx/x64/tools-mono/GodotSharp/Api Godot_mono.app/Contents/Frameworks/GodotSharp
+  cp -rp out/macosx/x64/tools-mono/GodotSharp/Mono/lib Godot_mono.app/Contents/Frameworks/GodotSharp/Mono
+  cp -rp out/macosx/x64/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
+  cp -rp out/macosx/x64/tools-mono/GodotSharp/Mono/etc Godot_mono.app/Contents/Resources/GodotSharp/Mono
+  chmod +x Godot_mono.app/Contents/MacOS/Godot
+  zip -q -9 -r "${reldir_mono}/${binname}.zip" Godot_mono.app
+  rm -rf Godot_mono.app
+
+  # Templates
+  rm -rf osx_template.app
+  cp -r git/misc/dist/osx_template.app .
+  mkdir -p osx_template.app/Contents/MacOS
+
+  cp out/macosx/x64/templates-mono/godot.osx.opt.debug.64.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
+  cp out/macosx/x64/templates-mono/godot.osx.opt.64.mono osx_template.app/Contents/MacOS/godot_osx_release.64
+  cp -rp out/macosx/x64/templates-mono/data.mono.osx.64.* osx_template.app/Contents/MacOS/
+  chmod +x osx_template.app/Contents/MacOS/godot_osx*
+  zip -q -9 -r "${templatesdir_mono}/osx.zip" osx_template.app
+  rm -rf osx_template.app
+
+  ## Server (Mono) ##
+
+  # Headless (editor)
+  binbasename="${godot_basename}_mono_linux_headless"
+  mkdir -p ${binbasename}_64
+  cp out/server/x64/tools-mono/godot_server.x11.opt.tools.64.mono ${binbasename}_64/${binbasename}.64
+  cp -rp out/server/x64/tools-mono/GodotSharp ${binbasename}_64/
+  zip -r -q -9 "${reldir_mono}/${binbasename}_64.zip" ${binbasename}_64
+  rm -rf ${binbasename}_64
+
+  # Server (template)
+  binbasename="${godot_basename}_mono_linux_server"
+  mkdir -p ${binbasename}_64
+  cp out/server/x64/templates-mono/godot_server.x11.opt.64.mono ${binbasename}_64/${binbasename}.64
+  cp -rp out/server/x64/templates-mono/data.mono.server.64.release ${binbasename}_64/data_${binbasename}_64
+  zip -r -q -9 "${reldir_mono}/${binbasename}_64.zip" ${binbasename}_64
+  rm -rf ${binbasename}_64
+
+  ## Javascript (Mono) ##
+
+  # Templates
+  cp out/javascript/templates-mono/godot.javascript.opt.debug.mono.zip ${templatesdir_mono}/webassembly_debug.zip
+  cp out/javascript/templates-mono/godot.javascript.opt.mono.zip ${templatesdir_mono}/webassembly_release.zip
+
+  mkdir -p ${templatesdir_mono}/bcl
+  cp -r out/javascript/templates-mono/bcl/wasm ${templatesdir_mono}/bcl/
+
+  ## Android (Mono) ##
+
+  # Templates
+  cp out/android/templates-mono/*.apk ${templatesdir_mono}/
+  cp out/android/templates-mono/android_source.zip ${templatesdir_mono}/
+
+  mkdir -p ${templatesdir_mono}/bcl
+  cp -r out/android/templates-mono/bcl/monodroid ${templatesdir_mono}/bcl/
+
+  ## iOS (Mono) ##
+
+  # Not supported yet.
+
+  ## UWP (Mono) ##
+
+  # Not supported yet.
+
+fi
+
+echo "All editor binaries and templates prepared successfully for release"

--- a/build-server/build.sh
+++ b/build-server/build.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+# Config
+
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes debug_symbols=no use_static_cpp=yes use_lto=yes"
+export OPTIONS="debug_symbols=no use_static_cpp=yes use_lto=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 export CC="gcc-8"
@@ -15,27 +17,41 @@ mkdir godot
 cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
-cp /root/mono-glue/*.cpp modules/mono/glue/
-cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+# Classical
 
-$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=yes target=release_debug
-mkdir -p /root/out/tools
-cp -rvp bin/* /root/out/tools
-rm -rf bin
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for Server..."
 
-#$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=no target=release_debug
-$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=no target=release
-mkdir -p /root/out/templates
-cp -rvp bin/* /root/out/templates
-rm -rf bin
+  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=yes target=release_debug
+  mkdir -p /root/out/tools
+  cp -rvp bin/* /root/out/tools
+  rm -rf bin
 
-$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
-mkdir -p /root/out/tools
-cp -rvp bin/* /root/out/tools
-rm -rf bin
+  #$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=no target=release_debug
+  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=no target=release
+  mkdir -p /root/out/templates
+  cp -rvp bin/* /root/out/templates
+  rm -rf bin
+fi
 
-#$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release_debug
-$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release
-mkdir -p /root/out/templates
-cp -rvp bin/* /root/out/templates
-rm -rf bin
+# Mono
+
+if [ "${MONO}" == "1" ]; then
+  echo "Starting Mono build for Server..."
+
+  cp /root/mono-glue/*.cpp modules/mono/glue/
+  cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+
+  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
+  mkdir -p /root/out/tools-mono
+  cp -rvp bin/* /root/out/tools-mono
+  rm -rf bin
+
+  #$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release
+  mkdir -p /root/out/templates-mono
+  cp -rvp bin/* /root/out/templates-mono
+  rm -rf bin
+fi
+
+echo "Server build successful"

--- a/build-uwp/build.sh
+++ b/build-uwp/build.sh
@@ -2,25 +2,43 @@
 
 set -e
 
-export ANGLE_SRC_PATH='c:\angle'
+# Config
+
 export BUILD_NAME=official
 export SCONS="call scons -j4 verbose=yes warnings=no progress=no"
-export OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes debug_symbols=no"
+export OPTIONS="debug_symbols=no"
+export BUILD_ARCHES="x86 x64 arm"
+export ANGLE_SRC_PATH='c:\angle'
 
 rm -rf godot
 mkdir godot
 cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
-for arch in x86 x64 arm; do
-  for release in release release_debug; do
-    wine cmd /c /root/build/build.bat $arch $release
+# Classical
 
-    sync
-    wineserver -kw
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for Server..."
 
-    mkdir -p /root/out/$arch
-    mv bin/* /root/out/$arch
+  for arch in ${BUILD_ARCHES}; do
+    for release in release release_debug; do
+      wine cmd /c /root/build/build.bat $arch $release
+
+      sync
+      wineserver -kw
+
+      mkdir -p /root/out/$arch
+      mv bin/* /root/out/$arch
+    done
   done
-done
+fi
 
+# Mono
+
+if [ "${MONO}" == "1" ]; then
+  echo "No Mono support for UWP yet."
+  #cp /root/mono-glue/*.cpp modules/mono/glue/
+  #cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+fi
+
+echo "UWP build successful"

--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+# Config
+
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes debug_symbols=no use_static_cpp=yes use_lto=yes"
+export OPTIONS="debug_symbols=no use_lto=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 export MONO32_PREFIX=/root/dependencies/mono-32
@@ -15,49 +17,63 @@ mkdir godot
 cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
-cp /root/mono-glue/*.cpp modules/mono/glue/
-cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+# Classical
 
-$SCONS platform=windows bits=32 $OPTIONS tools=yes target=release_debug
-mkdir -p /root/out/x86/tools
-cp -rvp bin/* /root/out/x86/tools
-rm -rf bin
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for Windows..."
 
-$SCONS platform=windows bits=32 $OPTIONS tools=no target=release_debug
-$SCONS platform=windows bits=32 $OPTIONS tools=no target=release
-mkdir -p /root/out/x86/templates
-cp -rvp bin/* /root/out/x86/templates
-rm -rf bin
+  $SCONS platform=windows bits=64 $OPTIONS tools=yes target=release_debug
+  mkdir -p /root/out/x64/tools
+  cp -rvp bin/* /root/out/x64/tools
+  rm -rf bin
 
-$SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=yes target=release_debug copy_mono_root=yes
-mkdir -p /root/out/x86/tools-mono
-cp -rvp bin/* /root/out/x86/tools-mono
-rm -rf bin
+  $SCONS platform=windows bits=64 $OPTIONS tools=no target=release_debug
+  $SCONS platform=windows bits=64 $OPTIONS tools=no target=release
+  mkdir -p /root/out/x64/templates
+  cp -rvp bin/* /root/out/x64/templates
+  rm -rf bin
 
-$SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=no target=release_debug
-$SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=no target=release
-mkdir -p /root/out/x86/templates-mono
-cp -rvp bin/* /root/out/x86/templates-mono
-rm -rf bin
+  $SCONS platform=windows bits=32 $OPTIONS tools=yes target=release_debug
+  mkdir -p /root/out/x86/tools
+  cp -rvp bin/* /root/out/x86/tools
+  rm -rf bin
 
-$SCONS platform=windows bits=64 $OPTIONS tools=yes target=release_debug
-mkdir -p /root/out/x64/tools
-cp -rvp bin/* /root/out/x64/tools
-rm -rf bin
+  $SCONS platform=windows bits=32 $OPTIONS tools=no target=release_debug
+  $SCONS platform=windows bits=32 $OPTIONS tools=no target=release
+  mkdir -p /root/out/x86/templates
+  cp -rvp bin/* /root/out/x86/templates
+  rm -rf bin
+fi
 
-$SCONS platform=windows bits=64 $OPTIONS tools=no target=release_debug
-$SCONS platform=windows bits=64 $OPTIONS tools=no target=release
-mkdir -p /root/out/x64/templates
-cp -rvp bin/* /root/out/x64/templates
-rm -rf bin
+# Mono
 
-$SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=yes target=release_debug copy_mono_root=yes
-mkdir -p /root/out/x64/tools-mono
-cp -rvp bin/* /root/out/x64/tools-mono
-rm -rf bin
+if [ "${MONO}" == "1" ]; then
+  echo "Starting Mono build for Windows..."
 
-$SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=no target=release_debug
-$SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=no target=release
-mkdir -p /root/out/x64/templates-mono
-cp -rvp bin/* /root/out/x64/templates-mono
-rm -rf bin
+  cp /root/mono-glue/*.cpp modules/mono/glue/
+  cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+
+  $SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  mkdir -p /root/out/x64/tools-mono
+  cp -rvp bin/* /root/out/x64/tools-mono
+  rm -rf bin
+
+  $SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=no target=release_debug
+  $SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=no target=release
+  mkdir -p /root/out/x64/templates-mono
+  cp -rvp bin/* /root/out/x64/templates-mono
+  rm -rf bin
+
+  $SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  mkdir -p /root/out/x86/tools-mono
+  cp -rvp bin/* /root/out/x86/tools-mono
+  rm -rf bin
+
+  $SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=no target=release_debug
+  $SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=no target=release
+  mkdir -p /root/out/x86/templates-mono
+  cp -rvp bin/* /root/out/x86/templates-mono
+  rm -rf bin
+fi
+
+echo "Windows build successful"


### PR DESCRIPTION
The in-container build scripts now get passed CLASSICAL and MONO env
variables which can be used to build one or the other, or both
(default).

`build.sh`, `build-release.sh` and `build-templates.sh` now all expect
command line switches to specify the version details, and optionally
which flavor to build.

For example to build Mono only:

```
  ./build.sh -v 3.2-beta4 -g master -b mono
  ./build-release.sh -v 3.2-beta4 -b mono
  ./build-templates.sh -v 3.2-beta4 -t 3.2.beta4 -b mono
```

Also took the opportunity to do some extra cleanup, like removing
unnecessary `builtin_*` options since they all default to True, even
for Linux in 3.2.

And I improved the `build-release.sh` script to be a bit easier to
read, and avoid having too many stray folders to cleanup.
The build scripts should now generate the final structure that we'd use
on the official mirrors, with the `mono` distribution as a subfolder of
the main release folder.

---

This is all untested for now, I'm running a test build on the buildsystem and I'll fix any potential typos/issues with the new system.