### PR TITLE
Mono: Add support for iOS

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -6,11 +6,14 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export IOS_SDK="12.4"
-export OPTIONS="osxcross_sdk=darwin18 debug_symbols=no"
+export OPTIONS="debug_symbols=no"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
-export OSXCROSS_IOS=not_nothing
+
+export IOS_SDK="12.4"
+export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
+
+export IOS_GODOT_LIBS="libgodot libgodot_arkit_module libgodot_camera_module"
 
 rm -rf godot
 mkdir godot
@@ -22,28 +25,61 @@ tar xf /root/godot.tar.gz --strip-components=1
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for iOS..."
 
-  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release_debug IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
-  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release_debug \
+    osxcross_sdk=darwin18 IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release \
+    osxcross_sdk=darwin18 IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
 
-  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release_debug IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
-  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release_debug \
+    osxcross_sdk=darwin18 IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release \
+    osxcross_sdk=darwin18 IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
 
-  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot.iphone.opt.arm64.a bin/libgodot.iphone.opt.x86_64.a -output /root/out/libgodot.iphone.opt.fat
-  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot.iphone.opt.debug.arm64.a bin/libgodot.iphone.opt.debug.x86_64.a -output /root/out/libgodot.iphone.opt.debug.fat
-
-  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_arkit_module.iphone.opt.arm64.a bin/libgodot_arkit_module.iphone.opt.x86_64.a -output /root/out/libgodot_arkit_module.iphone.opt.fat
-  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_arkit_module.iphone.opt.debug.arm64.a bin/libgodot_arkit_module.iphone.opt.debug.x86_64.a -output /root/out/libgodot_arkit_module.iphone.opt.debug.fat
-
-  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_camera_module.iphone.opt.arm64.a bin/libgodot_camera_module.iphone.opt.x86_64.a -output /root/out/libgodot_camera_module.iphone.opt.fat
-  /root/ioscross/arm64/bin/arm-apple-darwin11-lipo -create bin/libgodot_camera_module.iphone.opt.debug.arm64.a bin/libgodot_camera_module.iphone.opt.debug.x86_64.a -output /root/out/libgodot_camera_module.iphone.opt.debug.fat
+  mkdir -p /root/out/templates
+  for lib in $IOS_GODOT_LIBS; do
+    $IOS_LIPO -create bin/${lib}.iphone.opt.arm64.a bin/${lib}.iphone.opt.x86_64.a -output /root/out/templates/${lib}.iphone.opt.fat
+    $IOS_LIPO -create bin/${lib}.iphone.opt.debug.arm64.a bin/${lib}.iphone.opt.debug.x86_64.a -output /root/out/templates/${lib}.iphone.opt.debug.fat
+  done
 fi
 
 # Mono
 
 if [ "${MONO}" == "1" ]; then
-  echo "No Mono support for iOS yet."
-  #cp /root/mono-glue/*.cpp modules/mono/glue/
-  #cp -r /root/mono-glue/Managed/Generated modules/mono/glue/Managed/
+  echo "Starting Mono build for iOS..."
+
+  cp /root/mono-glue/*.cpp modules/mono/glue/
+  cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
+  cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
+
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 mono_prefix=/root/mono-installs/ios-arm64-release tools=no target=release_debug \
+    osxcross_sdk=darwin18 IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 mono_prefix=/root/mono-installs/ios-arm64-release tools=no target=release \
+    osxcross_sdk=darwin18 IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
+
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=x86_64 mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release_debug \
+    osxcross_sdk=darwin18 IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=x86_64 mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release \
+    osxcross_sdk=darwin18 IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
+
+  mkdir -p /root/out/templates-mono
+  for lib in $IOS_GODOT_LIBS; do
+    $IOS_LIPO -create bin/${lib}.iphone.opt.arm64.a bin/${lib}.iphone.opt.x86_64.a -output /root/out/templates-mono/${lib}.iphone.opt.fat
+    $IOS_LIPO -create bin/${lib}.iphone.opt.debug.arm64.a bin/${lib}.iphone.opt.debug.x86_64.a -output /root/out/templates-mono/${lib}.iphone.opt.debug.fat
+  done
+
+  mkdir -p /root/out/templates-mono/iphone-mono-libs
+
+  $IOS_LIPO -create bin/libmonosgen-2.0.iphone.arm64.a bin/libmonosgen-2.0.iphone.x86_64.a -output /root/out/templates-mono/iphone-mono-libs/libmonosgen-2.0.iphone.fat.a
+  $IOS_LIPO -create bin/libmono-native.iphone.arm64.a bin/libmono-native.iphone.x86_64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-native.iphone.fat.a
+  $IOS_LIPO -create bin/libmono-profiler-log.iphone.arm64.a bin/libmono-profiler-log.iphone.x86_64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-profiler-log.iphone.fat.a
+
+  # The Mono libraries for the interpreter are not available for simulator builds
+  $IOS_LIPO -create bin/libmono-ee-interp.iphone.arm64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-ee-interp.iphone.fat.a
+  $IOS_LIPO -create bin/libmono-icall-table.iphone.arm64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-icall-table.iphone.fat.a
+  $IOS_LIPO -create bin/libmono-ilgen.iphone.arm64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-ilgen.iphone.fat.a
+
+  mkdir -p /root/out/templates-mono/bcl
+  cp -r /root/mono-installs/ios-bcl/* /root/out/templates-mono/bcl
 fi
 
 echo "iOS build successful"

--- a/build-release.sh
+++ b/build-release.sh
@@ -177,8 +177,8 @@ if [ "${build_classical}" == "1" ]; then
   rm -rf ios_xcode
   cp -r git/misc/dist/ios_xcode ios_xcode
   for suffix in "" "_arkit_module" "_camera_module"; do
-    cp out/ios/libgodot${suffix}.iphone.opt.fat ios_xcode/libgodot${suffix}.iphone.release.fat.a
-    cp out/ios/libgodot${suffix}.iphone.opt.debug.fat ios_xcode/libgodot${suffix}.iphone.debug.fat.a
+    cp out/ios/templates/libgodot${suffix}.iphone.opt.fat ios_xcode/libgodot${suffix}.iphone.release.fat.a
+    cp out/ios/templates/libgodot${suffix}.iphone.opt.debug.fat ios_xcode/libgodot${suffix}.iphone.debug.fat.a
   done
   chmod +x ios_xcode/libgodot*.iphone.*
   cd ios_xcode
@@ -234,6 +234,7 @@ if [ "${build_mono}" == "1" ]; then
   mkdir -p ${binbasename}_64
   cp out/linux/x64/tools-mono/godot.x11.opt.tools.64.mono ${binbasename}_64/${binbasename}.64
   cp -rp out/linux/x64/tools-mono/GodotSharp ${binbasename}_64/
+  cp -rp out/aot-compilers ${binbasename}_64/GodotSharp/Tools/
   zip -r -q -9 "${reldir_mono}/${binbasename}_64.zip" ${binbasename}_64
   rm -rf ${binbasename}_64
 
@@ -241,6 +242,7 @@ if [ "${build_mono}" == "1" ]; then
   mkdir -p ${binbasename}_32
   cp out/linux/x86/tools-mono/godot.x11.opt.tools.32.mono ${binbasename}_32/${binbasename}.32
   cp -rp out/linux/x86/tools-mono/GodotSharp/ ${binbasename}_32/
+  cp -rp out/aot-compilers ${binbasename}_32/GodotSharp/Tools/
   zip -r -q -9 "${reldir_mono}/${binbasename}_32.zip" ${binbasename}_32
   rm -rf ${binbasename}_32
 
@@ -264,6 +266,7 @@ if [ "${build_mono}" == "1" ]; then
   strip ${binname}/${binname}.exe
   sign ${binname}/${binname}.exe
   cp -rp out/windows/x64/tools-mono/GodotSharp ${binname}/
+  cp -rp out/aot-compilers ${binname}/GodotSharp/Tools/
   zip -r -q -9 "${reldir_mono}/${binname}.zip" ${binname}
   rm -rf ${binname}
 
@@ -273,6 +276,7 @@ if [ "${build_mono}" == "1" ]; then
   strip ${binname}/${binname}.exe
   sign ${binname}/${binname}.exe
   cp -rp out/windows/x86/tools-mono/GodotSharp ${binname}/
+  cp -rp out/aot-compilers ${binname}/GodotSharp/Tools/
   zip -r -q -9 "${reldir_mono}/${binname}.zip" ${binname}
   rm -rf ${binname}
 
@@ -304,6 +308,7 @@ if [ "${build_mono}" == "1" ]; then
   cp -rp out/macosx/x64/tools-mono/GodotSharp/Mono/lib Godot_mono.app/Contents/Frameworks/GodotSharp/Mono
   cp -rp out/macosx/x64/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
   cp -rp out/macosx/x64/tools-mono/GodotSharp/Mono/etc Godot_mono.app/Contents/Resources/GodotSharp/Mono
+  cp -rp out/aot-compilers Godot_mono.app/Contents/Frameworks/GodotSharp/Tools/
   chmod +x Godot_mono.app/Contents/MacOS/Godot
   zip -q -9 -r "${reldir_mono}/${binname}.zip" Godot_mono.app
   rm -rf Godot_mono.app
@@ -327,6 +332,7 @@ if [ "${build_mono}" == "1" ]; then
   mkdir -p ${binbasename}_64
   cp out/server/x64/tools-mono/godot_server.x11.opt.tools.64.mono ${binbasename}_64/${binbasename}.64
   cp -rp out/server/x64/tools-mono/GodotSharp ${binbasename}_64/
+  cp -rp out/aot-compilers ${binbasename}_64/GodotSharp/Tools/
   zip -r -q -9 "${reldir_mono}/${binbasename}_64.zip" ${binbasename}_64
   rm -rf ${binbasename}_64
 
@@ -359,7 +365,22 @@ if [ "${build_mono}" == "1" ]; then
 
   ## iOS (Mono) ##
 
-  # Not supported yet.
+  rm -rf ios_xcode
+  cp -r git/misc/dist/ios_xcode ios_xcode
+  for suffix in "" "_arkit_module" "_camera_module"; do
+    cp out/ios/templates-mono/libgodot${suffix}.iphone.opt.fat ios_xcode/libgodot${suffix}.iphone.release.fat.a
+    cp out/ios/templates-mono/libgodot${suffix}.iphone.opt.debug.fat ios_xcode/libgodot${suffix}.iphone.debug.fat.a
+  done
+  chmod +x ios_xcode/libgodot*.iphone.*
+  cd ios_xcode
+  zip -q -9 -r "${templatesdir_mono}/iphone.zip" *
+  cd ..
+  rm -rf ios_xcode
+
+  mkdir -p ${templatesdir_mono}/bcl
+  cp -r out/ios/templates-mono/bcl/monotouch* ${templatesdir_mono}/bcl/
+
+  cp -r out/ios/templates-mono/iphone-mono-libs ${templatesdir_mono}/
 
   ## UWP (Mono) ##
 

--- a/build.sh
+++ b/build.sh
@@ -150,6 +150,11 @@ mkdir -p ${basedir}/out/logs
 export podman_run="${podman} run -it --rm --env NUM_CORES --env CLASSICAL=${build_classical} --env MONO=${build_mono} -v ${basedir}/godot.tar.gz:/root/godot.tar.gz -v ${basedir}/mono-glue:/root/mono-glue -w /root/"
 export img_version=3.2-mono-6.6.0.166
 
+# Get AOT compilers from their containers.
+mkdir -p ${basedir}/out/aot-compilers
+${podman} run -it --rm -w /root -v ${basedir}/out/aot-compilers:/root/out localhost/godot-ios:${img_version} bash -c "cp -r /root/aot-compilers/* /root/out"
+chmod +x ${basedir}/out/aot-compilers/*/*
+
 mkdir -p ${basedir}/mono-glue
 ${podman_run} -v ${basedir}/build-mono-glue:/root/build localhost/godot-mono-glue:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/mono-glue
 


### PR DESCRIPTION
It seems to work fine with the (intermediate) container build that I get with https://github.com/godotengine/build-containers/pull/47 (without cross-compiling toolchain).

BTW, how does the AOT toolchain intervene in the build/packaging of the templates? Or is it something that should be bundled alongside the editor builds for all desktop platforms?