### PR TITLE
Compute and backup SHA-512 sums for release files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ godot.tar.gz
 # Output
 out/
 releases/
+sha512sums/
 tmp/

--- a/build-release.sh
+++ b/build-release.sh
@@ -238,6 +238,14 @@ if [ "${build_classical}" == "1" ]; then
   zip -q -9 -r -D "${reldir}/${godot_basename}_export_templates.tpz" templates/*
   popd
 
+  ## SHA-512 sums (Classical) ##
+
+  pushd ${reldir}
+  sha512sum [Gg]* > SHA512-SUMS.txt
+  mkdir -p ${basedir}/sha512sums/${godot_version}
+  cp SHA512-SUMS.txt ${basedir}/sha512sums/${godot_version}/
+  popd
+
 fi
 
 # Mono
@@ -408,6 +416,14 @@ if [ "${build_mono}" == "1" ]; then
   echo "${templates_version}.mono" > ${templatesdir_mono}/version.txt
   pushd ${templatesdir_mono}/..
   zip -q -9 -r -D "${reldir_mono}/${godot_basename}_mono_export_templates.tpz" templates/*
+  popd
+
+  ## SHA-512 sums (Mono) ##
+
+  pushd ${reldir_mono}
+  sha512sum [Gg]* >> SHA512-SUMS.txt
+  mkdir -p ${basedir}/sha512sums/${godot_version}/mono
+  cp SHA512-SUMS.txt ${basedir}/sha512sums/${godot_version}/mono/
   popd
 
 fi


### PR DESCRIPTION
The sums are included both in the release folder, and in a separate
`sha512sums` folder in the base directory, to allow verifying that
the sums on the download repository haven't been tampered with.