### PR TITLE
Mono: Workaround segfault issue with Mono MSBuild on Ubuntu 14.04

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -48,7 +48,11 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
 
-  $SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
+  # Workaround for MSBuild segfault on Ubuntu containers, we build the CIL on Fedora and copy here.
+  mkdir -p bin
+  cp -r /root/mono-glue/cil/GodotSharp bin/
+
+  $SCONS platform=x11 CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes build_cil=no
   mkdir -p /root/out/tools-mono
   cp -rvp bin/* /root/out/tools-mono
   rm -rf bin

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -26,6 +26,14 @@ if [ "${MONO}" == "1" ]; then
 
   rm -rf /root/mono-glue/*
   xvfb-run bin/godot.x11.opt.tools.64.mono --generate-mono-glue /root/mono-glue || /bin/true
+
+  # Build and copy CIL that we'll need for Ubuntu 14.04 Linux builds
+  # to workaround Mono MSBuild segfault in our containers.
+  xvfb-run bin/godot.x11.opt.tools.64.mono --generate-mono-glue modules/mono/glue || /bin/true
+  ${SCONS} platform=x11 bits=64 ${OPTIONS} target=release_debug tools=yes module_mono_enabled=yes mono_glue=yes build_cil=yes
+
+  mkdir /root/mono-glue/cil
+  cp -r bin/GodotSharp /root/mono-glue/cil/
 fi
 
 echo "Mono glue generated successfully"

--- a/build-server/build.sh
+++ b/build-server/build.sh
@@ -43,7 +43,11 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
-  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
+  # Workaround for MSBuild segfault on Ubuntu containers, we build the CIL on Fedora and copy here.
+  mkdir -p bin
+  cp -r /root/mono-glue/cil/GodotSharp bin/
+
+  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes build_cil=no
   mkdir -p /root/out/tools-mono
   cp -rvp bin/* /root/out/tools-mono
   rm -rf bin


### PR DESCRIPTION
Using the dotnet CLI can be a valid workaround, but it's not available
for 32-bit Linux.

Instead, we build the Godot API and GodotTools solutions (CIL) on Fedora
in the mono-glue container, and copy them to the Ubuntu-based Linux
containers.