### PR TITLE
Android: Add .mono suffix for the Mono-enabled AAR

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -384,7 +384,7 @@ if [ "${build_mono}" == "1" ]; then
   ## Android (Mono) ##
 
   # Lib for direct download
-  cp out/android/templates-mono/godot-lib.release.aar ${reldir_mono}/godot-lib.${templates_version}.release.aar
+  cp out/android/templates-mono/godot-lib.release.aar ${reldir_mono}/godot-lib.${templates_version}.mono.release.aar
 
   # Templates
   cp out/android/templates-mono/*.apk ${templatesdir_mono}/


### PR DESCRIPTION
FYI @m4gr3d - I think it makes sense to use the `.mono` suffix here to distinguish between the two variants.

(Already used this commit for 3.2.2 RC 1 and RC 2.)