### PR TITLE
OSX: Build universal binaries with ARM64

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -10,7 +10,7 @@ export OPTIONS="debug_symbols=no"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 
-export IOS_SDK="14.0"
+export IOS_SDK="14.2"
 export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
 
 export IOS_GODOT_LIBS="libgodot libgodot_arkit_module libgodot_camera_module"

--- a/build-macosx/build.sh
+++ b/build-macosx/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="osxcross_sdk=darwin19 debug_symbols=no"
+export OPTIONS="osxcross_sdk=darwin20 debug_symbols=no"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/dependencies/mono"
 export TERM=xterm
 
@@ -20,14 +20,20 @@ tar xf /root/godot.tar.gz --strip-components=1
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for macOS..."
 
-  $SCONS platform=osx $OPTIONS tools=yes target=release_debug
+  $SCONS platform=osx $OPTIONS arch=x86_64 tools=yes target=release_debug
+  $SCONS platform=osx $OPTIONS arch=arm64 tools=yes target=release_debug
+  lipo -create bin/godot.osx.opt.tools.x86_64 bin/godot.osx.opt.tools.arm64 -output bin/godot.osx.opt.tools.universal
 
   mkdir -p /root/out/tools
   cp -rvp bin/* /root/out/tools
   rm -rf bin
 
-  $SCONS platform=osx $OPTIONS tools=no target=release_debug
-  $SCONS platform=osx $OPTIONS tools=no target=release
+  $SCONS platform=osx $OPTIONS arch=x86_64 tools=no target=release_debug
+  $SCONS platform=osx $OPTIONS arch=arm64 tools=no target=release_debug
+  lipo -create bin/godot.osx.opt.debug.x86_64 bin/godot.osx.opt.debug.arm64 -output bin/godot.osx.opt.debug.universal
+  $SCONS platform=osx $OPTIONS arch=x86_64 tools=no target=release
+  $SCONS platform=osx $OPTIONS arch=arm64 tools=no target=release
+  lipo -create bin/godot.osx.opt.x86_64 bin/godot.osx.opt.arm64 -output bin/godot.osx.opt.universal
 
   mkdir -p /root/out/templates
   cp -rvp bin/* /root/out/templates
@@ -43,14 +49,20 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
-  $SCONS platform=osx $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=x86_64 tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=arm64 tools=yes target=release_debug copy_mono_root=yes
+  lipo -create bin/godot.osx.opt.tools.x86_64.mono bin/godot.osx.opt.tools.arm64.mono -output bin/godot.osx.opt.tools.universal.mono
 
   mkdir -p /root/out/tools-mono
   cp -rvp bin/* /root/out/tools-mono
   rm -rf bin
 
-  $SCONS platform=osx $OPTIONS $OPTIONS_MONO tools=no target=release_debug
-  $SCONS platform=osx $OPTIONS $OPTIONS_MONO tools=no target=release
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=x86_64 tools=no target=release_debug
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=arm64 tools=no target=release_debug
+  lipo -create bin/godot.osx.opt.debug.x86_64.mono bin/godot.osx.opt.debug.arm64.mono -output bin/godot.osx.opt.debug.universal.mono
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=x86_64 tools=no target=release
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=arm64 tools=no target=release
+  lipo -create bin/godot.osx.opt.x86_64.mono bin/godot.osx.opt.arm64.mono -output bin/godot.osx.opt.universal.mono
 
   mkdir -p /root/out/templates-mono
   cp -rvp bin/* /root/out/templates-mono

--- a/build-release.sh
+++ b/build-release.sh
@@ -136,11 +136,11 @@ if [ "${build_classical}" == "1" ]; then
   ## OSX (Classical) ##
 
   # Editor
-  binname="${godot_basename}_osx.64"
+  binname="${godot_basename}_osx.universal"
   rm -rf Godot.app
   cp -r git/misc/dist/osx_tools.app Godot.app
   mkdir -p Godot.app/Contents/MacOS
-  cp out/macosx/x64/tools/godot.osx.opt.tools.64 Godot.app/Contents/MacOS/Godot
+  cp out/macosx/tools/godot.osx.opt.tools.universal Godot.app/Contents/MacOS/Godot
   chmod +x Godot.app/Contents/MacOS/Godot
   zip -q -9 -r "${reldir}/${binname}.zip" Godot.app
   rm -rf Godot.app
@@ -150,8 +150,8 @@ if [ "${build_classical}" == "1" ]; then
   cp -r git/misc/dist/osx_template.app .
   mkdir -p osx_template.app/Contents/MacOS
 
-  cp out/macosx/x64/templates/godot.osx.opt.64 osx_template.app/Contents/MacOS/godot_osx_release.64
-  cp out/macosx/x64/templates/godot.osx.opt.debug.64 osx_template.app/Contents/MacOS/godot_osx_debug.64
+  cp out/macosx/templates/godot.osx.opt.universal osx_template.app/Contents/MacOS/godot_osx_release.64
+  cp out/macosx/templates/godot.osx.opt.debug.universal osx_template.app/Contents/MacOS/godot_osx_debug.64
   chmod +x osx_template.app/Contents/MacOS/godot_osx*
   zip -q -9 -r "${templatesdir}/osx.zip" osx_template.app
   rm -rf osx_template.app
@@ -324,18 +324,18 @@ if [ "${build_mono}" == "1" ]; then
   ## OSX (Mono) ##
 
   # Editor
-  binname="${godot_basename}_mono_osx.64"
+  binname="${godot_basename}_mono_osx.universal"
   rm -rf Godot_mono.app
   cp -r git/misc/dist/osx_tools.app Godot_mono.app
   mkdir -p Godot_mono.app/Contents/MacOS
-  cp out/macosx/x64/tools-mono/godot.osx.opt.tools.64.mono Godot_mono.app/Contents/MacOS/Godot
+  cp out/macosx/tools-mono/godot.osx.opt.tools.universal.mono Godot_mono.app/Contents/MacOS/Godot
   mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}
   mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp
   mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp/Mono
-  cp -rp out/macosx/x64/tools-mono/GodotSharp/Api Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/x64/tools-mono/GodotSharp/Mono/lib Godot_mono.app/Contents/Frameworks/GodotSharp/Mono
-  cp -rp out/macosx/x64/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/x64/tools-mono/GodotSharp/Mono/etc Godot_mono.app/Contents/Resources/GodotSharp/Mono
+  cp -rp out/macosx/tools-mono/GodotSharp/Api Godot_mono.app/Contents/Frameworks/GodotSharp
+  cp -rp out/macosx/tools-mono/GodotSharp/Mono/lib Godot_mono.app/Contents/Frameworks/GodotSharp/Mono
+  cp -rp out/macosx/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
+  cp -rp out/macosx/tools-mono/GodotSharp/Mono/etc Godot_mono.app/Contents/Resources/GodotSharp/Mono
   cp -rp out/aot-compilers Godot_mono.app/Contents/Frameworks/GodotSharp/Tools/
   chmod +x Godot_mono.app/Contents/MacOS/Godot
   zip -q -9 -r "${reldir_mono}/${binname}.zip" Godot_mono.app
@@ -346,9 +346,9 @@ if [ "${build_mono}" == "1" ]; then
   cp -r git/misc/dist/osx_template.app .
   mkdir -p osx_template.app/Contents/MacOS
 
-  cp out/macosx/x64/templates-mono/godot.osx.opt.debug.64.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
-  cp out/macosx/x64/templates-mono/godot.osx.opt.64.mono osx_template.app/Contents/MacOS/godot_osx_release.64
-  cp -rp out/macosx/x64/templates-mono/data.mono.osx.64.* osx_template.app/Contents/MacOS/
+  cp out/macosx/templates-mono/godot.osx.opt.debug.universal.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
+  cp out/macosx/templates-mono/godot.osx.opt.universal.mono osx_template.app/Contents/MacOS/godot_osx_release.64
+  cp -rp out/macosx/templates-mono/data.mono.osx.universal.* osx_template.app/Contents/MacOS/
   chmod +x osx_template.app/Contents/MacOS/godot_osx*
   zip -q -9 -r "${templatesdir_mono}/osx.zip" osx_template.app
   rm -rf osx_template.app

--- a/build.sh
+++ b/build.sh
@@ -185,8 +185,8 @@ ${podman_run} -v ${basedir}/build-linux:/root/build -v ${basedir}/out/linux/x86:
 mkdir -p ${basedir}/out/javascript
 ${podman_run} -v ${basedir}/build-javascript:/root/build -v ${basedir}/out/javascript:/root/out localhost/godot-javascript:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/javascript
 
-mkdir -p ${basedir}/out/macosx/x64
-${podman_run} -v ${basedir}/build-macosx:/root/build -v ${basedir}/out/macosx/x64:/root/out localhost/godot-osx:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/macosx
+mkdir -p ${basedir}/out/macosx
+${podman_run} -v ${basedir}/build-macosx:/root/build -v ${basedir}/out/macosx:/root/out localhost/godot-osx:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/macosx
 
 mkdir -p ${basedir}/out/android
 ${podman_run} -v ${basedir}/build-android:/root/build -v ${basedir}/out/android:/root/out localhost/godot-android:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/android


### PR DESCRIPTION
Untested for now, but preparing the ground for building universal binaries with ARM64 support for macOS.

Requirements to finish this:

- 1. [x] osxcross should first get support for the ARM64 target ([upstream issue](https://github.com/tpoechtrager/osxcross/issues/227)).
- 2. [x] [Dockerfile.xcode](https://github.com/godotengine/build-containers/blob/master/Dockerfile.xcode) and [Dockerfile.osx](https://github.com/godotengine/build-containers/blob/master/Dockerfile.osx) will need to be updated to build with Xcode 12 and the latest osxcross version when it supports ARM64. (Done with https://github.com/godotengine/build-containers/pull/60.)
- 3. [ ] [Dockerfile.osx](https://github.com/godotengine/build-containers/blob/master/Dockerfile.osx) should be updated to build Mono for ARM64.
   - [x] This depends on Mono actually getting [support for ARM64 merged](https://github.com/mono/mono/pull/20014) in the first place, 
   - [x] and also implies that we'd have to build against a fairly cutting-edge Mono version to get this support, as I guess they might not backport it to earlier branches. (Done with https://github.com/godotengine/build-containers/pull/58 and https://github.com/godotengine/build-containers/pull/59.)

Sooo... it's not for today ;)