### PR TITLE
Fixing Mono export templates and editor

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -330,10 +330,12 @@ if [ "${build_mono}" == "1" ]; then
   mkdir -p Godot_mono.app/Contents/MacOS
   cp out/macosx/tools-mono/godot.osx.opt.tools.universal.mono Godot_mono.app/Contents/MacOS/Godot
   mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}
-  mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp
-  cp -rp out/macosx/tools-mono/GodotSharp/Api Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/tools-mono/GodotSharp/Mono Godot_mono.app/Contents/Resources/GodotSharp
+  mkdir -p Godot_mono.app/Contents/Resources/GodotSharp
+  mkdir -p Godot_mono.app/Contents/Frameworks/Mono
+  cp -rp out/macosx/tools-mono/GodotSharp Godot_mono.app/Contents/Resources
+  mv Godot_mono.app/Contents/Resources/GodotSharp/Mono/lib/*.dylib Godot_mono.app/Contents/Frameworks/Mono
+  # cp /usr/local/lib/libMoltenVK.dylib Godot_mono.app/Contents/Frameworks
+  sed -i '' -e 's/$mono_libdir/$mono_libdir\/..\/..\/..\/..\/Frameworks\/Mono/g' Godot_mono.app/Contents/Resources/GodotSharp/Mono/etc/mono/config
 
   cp -rp out/aot-compilers Godot_mono.app/Contents/Frameworks/GodotSharp/Tools/
   chmod +x Godot_mono.app/Contents/MacOS/Godot
@@ -347,7 +349,15 @@ if [ "${build_mono}" == "1" ]; then
 
   cp out/macosx/templates-mono/godot.osx.opt.debug.universal.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
   cp out/macosx/templates-mono/godot.osx.opt.universal.mono osx_template.app/Contents/MacOS/godot_osx_release.64
-  cp -rp out/macosx/templates-mono/data.mono.osx.universal.* osx_template.app/Contents/Resources/
+
+  mkdir -p osx_template.app/Contents/Frameworks/data.mono.osx.64.frameworks.{release,release_debug}/lib
+  mkdir -p osx_template.app/Contents/Resources/data.mono.osx.64.resources.{release,release_debug}
+  cp -rp out/templates-mono/data.mono.osx.64.release/Mono/lib osx_template.app/Contents/Frameworks/data.mono.osx.64.frameworks.release
+  cp -rp out/templates-mono/data.mono.osx.64.release_debug/Mono/lib osx_template.app/Contents/Frameworks/data.mono.osx.64.frameworks.release_debug
+  cp -rp out/templates-mono/data.mono.osx.64.release/Mono/etc osx_template.app/Contents/Resources/data.mono.osx.64.resources.release
+  cp -rp out/templates-mono/data.mono.osx.64.release_debug/Mono/etc osx_template.app/Contents/Resources/data.mono.osx.64.resources.release_debug
+  # cp /usr/local/lib/libMoltenVK.dylib osx_template.app/Contents/Frameworks
+
   chmod +x osx_template.app/Contents/MacOS/godot_osx*
   zip -q -9 -r "${templatesdir_mono}/osx.zip" osx_template.app
   rm -rf osx_template.app

--- a/build-release.sh
+++ b/build-release.sh
@@ -331,11 +331,11 @@ if [ "${build_mono}" == "1" ]; then
   cp out/macosx/tools-mono/godot.osx.opt.tools.universal.mono Godot_mono.app/Contents/MacOS/Godot
   mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}
   mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp
-  mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp/Mono
+  mkdir -p Godot_mono.app/Contents/Resources/GodotSharp/Mono
   cp -rp out/macosx/tools-mono/GodotSharp/Api Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/tools-mono/GodotSharp/Mono/lib Godot_mono.app/Contents/Frameworks/GodotSharp/Mono
   cp -rp out/macosx/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/tools-mono/GodotSharp/Mono/etc Godot_mono.app/Contents/Resources/GodotSharp/Mono
+  cp -rp out/macosx/tools-mono/GodotSharp/Mono Godot_mono.app/Contents/Resources/GodotSharp/Mono
+
   cp -rp out/aot-compilers Godot_mono.app/Contents/Frameworks/GodotSharp/Tools/
   chmod +x Godot_mono.app/Contents/MacOS/Godot
   zip -q -9 -r "${reldir_mono}/${binname}.zip" Godot_mono.app
@@ -348,7 +348,7 @@ if [ "${build_mono}" == "1" ]; then
 
   cp out/macosx/templates-mono/godot.osx.opt.debug.universal.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
   cp out/macosx/templates-mono/godot.osx.opt.universal.mono osx_template.app/Contents/MacOS/godot_osx_release.64
-  cp -rp out/macosx/templates-mono/data.mono.osx.universal.* osx_template.app/Contents/MacOS/
+  cp -rp out/macosx/templates-mono/data.mono.osx.universal.* osx_template.app/Contents/Resources/
   chmod +x osx_template.app/Contents/MacOS/godot_osx*
   zip -q -9 -r "${templatesdir_mono}/osx.zip" osx_template.app
   rm -rf osx_template.app

--- a/build-release.sh
+++ b/build-release.sh
@@ -335,7 +335,7 @@ if [ "${build_mono}" == "1" ]; then
   cp -rp out/macosx/tools-mono/GodotSharp Godot_mono.app/Contents/Resources
   mv Godot_mono.app/Contents/Resources/GodotSharp/Mono/lib/*.dylib Godot_mono.app/Contents/Frameworks/Mono
   # cp /usr/local/lib/libMoltenVK.dylib Godot_mono.app/Contents/Frameworks
-  sed -i '' -e 's/$mono_libdir/$mono_libdir\/..\/..\/..\/..\/Frameworks\/Mono/g' Godot_mono.app/Contents/Resources/GodotSharp/Mono/etc/mono/config
+  sed -i -e 's/$mono_libdir/$mono_libdir\/..\/..\/..\/..\/Frameworks\/Mono/g' Godot_mono.app/Contents/Resources/GodotSharp/Mono/etc/mono/config
 
   cp -rp out/aot-compilers Godot_mono.app/Contents/Frameworks/GodotSharp/Tools/
   chmod +x Godot_mono.app/Contents/MacOS/Godot

--- a/build-release.sh
+++ b/build-release.sh
@@ -331,10 +331,9 @@ if [ "${build_mono}" == "1" ]; then
   cp out/macosx/tools-mono/godot.osx.opt.tools.universal.mono Godot_mono.app/Contents/MacOS/Godot
   mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}
   mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp
-  mkdir -p Godot_mono.app/Contents/Resources/GodotSharp/Mono
   cp -rp out/macosx/tools-mono/GodotSharp/Api Godot_mono.app/Contents/Frameworks/GodotSharp
   cp -rp out/macosx/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/tools-mono/GodotSharp/Mono Godot_mono.app/Contents/Resources/GodotSharp/Mono
+  cp -rp out/macosx/tools-mono/GodotSharp/Mono Godot_mono.app/Contents/Resources/GodotSharp
 
   cp -rp out/aot-compilers Godot_mono.app/Contents/Frameworks/GodotSharp/Tools/
   chmod +x Godot_mono.app/Contents/MacOS/Godot


### PR DESCRIPTION
This pairs with godotengine/godot#43768, which modifies the editor's export process to produce `.app`s that are able to be codesigned. With these changes, the official builds would be able to be signed, but more importantly, the pre-made templates would be ready to go. 