### PR TITLE
JS: Build with threads and gdnative where supported + re-enable LTO

### DIFF
--- a/build-javascript/build.sh
+++ b/build-javascript/build.sh
@@ -6,8 +6,8 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no use_lto=no"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release"
+export OPTIONS="debug_symbols=no use_lto=yes"
+export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no"
 export TERM=xterm
 
 rm -rf godot

--- a/build-javascript/build.sh
+++ b/build-javascript/build.sh
@@ -9,6 +9,8 @@ export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="debug_symbols=no use_lto=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no"
 export TERM=xterm
+export EMSDK_CLASSICAL=2.0.10
+export EMSDK_MONO=1.39.9
 
 rm -rf godot
 mkdir godot
@@ -20,8 +22,16 @@ tar xf /root/godot.tar.gz --strip-components=1
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for JavaScript..."
 
+  source /root/emsdk_${EMSDK_CLASSICAL}/emsdk_env.sh
+
   $SCONS platform=javascript ${OPTIONS} target=release_debug tools=no
   $SCONS platform=javascript ${OPTIONS} target=release tools=no
+
+  $SCONS platform=javascript ${OPTIONS} target=release_debug tools=no threads_enabled=yes
+  $SCONS platform=javascript ${OPTIONS} target=release tools=no threads_enabled=yes
+
+  $SCONS platform=javascript ${OPTIONS} target=release_debug tools=no gdnative_enabled=yes
+  $SCONS platform=javascript ${OPTIONS} target=release tools=no gdnative_enabled=yes
 
   mkdir -p /root/out/templates
   cp -rvp bin/*.zip /root/out/templates
@@ -32,6 +42,8 @@ fi
 
 if [ "${MONO}" == "1" ]; then
   echo "Starting Mono build for JavaScript..."
+
+  source /root/emsdk_${EMSDK_MONO}/emsdk_env.sh
 
   cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/

--- a/build-release.sh
+++ b/build-release.sh
@@ -176,6 +176,12 @@ if [ "${build_classical}" == "1" ]; then
   cp out/javascript/templates/godot.javascript.opt.zip ${templatesdir}/webassembly_release.zip
   cp out/javascript/templates/godot.javascript.opt.debug.zip ${templatesdir}/webassembly_debug.zip
 
+  cp out/javascript/templates/godot.javascript.opt.threads.zip ${templatesdir}/webassembly_threads_release.zip
+  cp out/javascript/templates/godot.javascript.opt.debug.threads.zip ${templatesdir}/webassembly_threads_debug.zip
+
+  cp out/javascript/templates/godot.javascript.opt.gdnative.zip ${templatesdir}/webassembly_gdnative_release.zip
+  cp out/javascript/templates/godot.javascript.opt.debug.gdnative.zip ${templatesdir}/webassembly_gdnative_debug.zip
+
   ## Android (Classical) ##
 
   # Lib for direct download


### PR DESCRIPTION
Classical builds now use Emscripten 2.0.10 and have threads and gdnative templates.
Mono builds still use Emscripten 1.39.9 for compatibility with Mono 6.12.x, so they
can only have threads support (GDNative requires 2.0.10+).