### PR TITLE
Add Apple Silicon iOS simulator build support. Build main lib and mono libs as `.xcframework`s.

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -24,19 +24,29 @@ tar xf /root/godot.tar.gz --strip-components=1
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for iOS..."
 
-  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release_debug \
+  #iOS arm64 device
+  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no ios_simulator=no target=release_debug \
     IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
-  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no target=release \
+  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no ios_simulator=no target=release \
     IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
 
-  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release_debug \
-    IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
-  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no target=release \
-    IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
+  #iOS arm64 simulator
+  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no ios_simulator=yes target=release_debug \
+    IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS arch=arm64 tools=no ios_simulator=no target=release \
+    IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+
+  #iOS x86_64 simulator
+  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no ios_simulator=yes target=release_debug \
+    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no ios_simulator=yes target=release \
+    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
 
   mkdir -p /root/out/templates
-  $IOS_LIPO -create bin/libgodot.iphone.opt.arm64.a bin/libgodot.iphone.opt.x86_64.a -output /root/out/templates/libgodot.iphone.opt.fat
-  $IOS_LIPO -create bin/libgodot.iphone.opt.debug.arm64.a bin/libgodot.iphone.opt.debug.x86_64.a -output /root/out/templates/libgodot.iphone.opt.debug.fat
+  $IOS_LIPO -create bin/libgodot.iphone.opt.arm64.simulator.a bin/libgodot.iphone.opt.x86_64.simulator.a -output /root/out/templates/libgodot.iphone.simulator.a
+  $IOS_LIPO -create bin/libgodot.iphone.opt.debug.arm64.simulator.a bin/libgodot.iphone.opt.debug.x86_64.simulator.a -output /root/out/templates/libgodot.iphone.debug.simulator.a
+  cp bin/libgodot.iphone.opt.arm64.a /root/out/templates/libgodot.iphone.a
+  cp bin/libgodot.iphone.opt.debug.arm64.a /root/out/templates/libgodot.iphone.debug.a
 fi
 
 # Mono
@@ -48,29 +58,45 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
-  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 mono_prefix=/root/mono-installs/ios-arm64-release tools=no target=release_debug \
+  #iOS arm64 device
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=no mono_prefix=/root/mono-installs/ios-arm64-release tools=no target=release_debug \
     IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
-  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 mono_prefix=/root/mono-installs/ios-arm64-release tools=no target=release \
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=no mono_prefix=/root/mono-installs/ios-arm64-release tools=no target=release \
     IPHONESDK="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
 
-  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=x86_64 mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release_debug \
-    IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
-  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=x86_64 mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release \
-    IPHONESDK="/root/ioscross/x86_64/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64/" ios_triple="x86_64-apple-darwin11-"
+  #iOS arm64 simulator
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-arm64-sim-release tools=no target=release_debug \
+    IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-arm64-sim-releasetools=no target=release \
+    IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+
+  #iOS x86_64 simulator
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release_debug \
+    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+  $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release \
+    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
 
   mkdir -p /root/out/templates-mono
-  $IOS_LIPO -create bin/libgodot.iphone.opt.arm64.a bin/libgodot.iphone.opt.x86_64.a -output /root/out/templates-mono/libgodot.iphone.opt.fat
-  $IOS_LIPO -create bin/libgodot.iphone.opt.debug.arm64.a bin/libgodot.iphone.opt.debug.x86_64.a -output /root/out/templates-mono/libgodot.iphone.opt.debug.fat
 
-  mkdir -p /root/out/templates-mono/iphone-mono-libs
-  $IOS_LIPO -create bin/libmonosgen-2.0.iphone.arm64.a bin/libmonosgen-2.0.iphone.x86_64.a -output /root/out/templates-mono/iphone-mono-libs/libmonosgen-2.0.iphone.fat.a
-  $IOS_LIPO -create bin/libmono-native.iphone.arm64.a bin/libmono-native.iphone.x86_64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-native.iphone.fat.a
-  $IOS_LIPO -create bin/libmono-profiler-log.iphone.arm64.a bin/libmono-profiler-log.iphone.x86_64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-profiler-log.iphone.fat.a
+  $IOS_LIPO -create bin/libgodot.iphone.opt.arm64.simulator.a bin/libgodot.iphone.opt.x86_64.simulator.a -output /root/out/templates-mono/libgodot.iphone.simulator.a
+  $IOS_LIPO -create bin/libgodot.iphone.opt.debug.arm64.simulator.a bin/libgodot.iphone.opt.debug.x86_64.simulator.a -output /root/out/templates-mono/libgodot.iphone.debug.simulator.a
+  cp bin/libgodot.iphone.opt.arm64.a /root/out/templates-mono/libgodot.iphone.a
+  cp bin/libgodot.iphone.opt.debug.arm64.a /root/out/templates-mono/libgodot.iphone.debug.a
+
+  cp -r misc/dist/iphone-mono-libs /root/out/templates-mono/iphone-mono-libs
+
+  $IOS_LIPO -create bin/libmonosgen-2.0.iphone.arm64.simulator.a bin/libmonosgen-2.0.iphone.x86_64.simulator.a -output /root/out/templates-mono/iphone-mono-libs/libmonosgen-2.0.xcframework/ios-arm64_x86_64-simulator/libmonosgen.a
+  $IOS_LIPO -create bin/libmono-native.iphone.arm64.simulator.a bin/libmono-native.iphone.x86_64.simulator.a -output /root/out/templates-mono/iphone-mono-libs/libmono-native.xcframework/ios-arm64_x86_64-simulator/libmono-native.a
+  $IOS_LIPO -create bin/libmono-profiler-log.iphone.arm64.simulator.a bin/libmono-profiler-log.iphone.x86_64.simulator.a -output /root/out/templates-mono/iphone-mono-libs/libmono-profiler-log.xcframework/ios-arm64_x86_64-simulator/libmono-profiler-log.a
+
+  cp bin/libmonosgen-2.0.iphone.arm64.a /root/out/templates-mono/iphone-mono-libs/libmonosgen-2.0.xcframework/ios-arm64/libmonosgen.a
+  cp bin/libmono-native.iphone.arm64.a /root/out/templates-mono/iphone-mono-libs/libmono-native.xcframework/ios-arm64/libmono-native.a
+  cp bin/libmono-profiler-log.iphone.arm64.a /root/out/templates-mono/iphone-mono-libs/libmono-profiler-log.xcframework/ios-arm64/libmono-profiler-log.a
 
   # The Mono libraries for the interpreter are not available for simulator builds
-  $IOS_LIPO -create bin/libmono-ee-interp.iphone.arm64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-ee-interp.iphone.fat.a
-  $IOS_LIPO -create bin/libmono-icall-table.iphone.arm64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-icall-table.iphone.fat.a
-  $IOS_LIPO -create bin/libmono-ilgen.iphone.arm64.a -output /root/out/templates-mono/iphone-mono-libs/libmono-ilgen.iphone.fat.a
+  cp bin/libmono-ee-interp.iphone.arm64.a /root/out/templates-mono/iphone-mono-libs/libmono-ee-interp.xcframework/ios-arm64/libmono-ee-interp.a
+  cp bin/libmono-icall-table.iphone.arm64.a /root/out/templates-mono/iphone-mono-libs/libmono-icall-table.xcframework/ios-arm64/libmono-icall-table.a
+  cp bin/libmono-ilgen.iphone.arm64.a /root/out/templates-mono/iphone-mono-libs/libmono-ilgen.xcframework/ios-arm64/libmono-ilgen.a
 
   mkdir -p /root/out/templates-mono/bcl
   cp -r /root/mono-installs/ios-bcl/* /root/out/templates-mono/bcl

--- a/build-release.sh
+++ b/build-release.sh
@@ -283,9 +283,10 @@ if [ "${build_classical}" == "1" ]; then
 
   rm -rf ios_xcode
   cp -r git/misc/dist/ios_xcode ios_xcode
-  cp out/ios/templates/libgodot.iphone.opt.fat ios_xcode/libgodot.iphone.release.fat.a
-  cp out/ios/templates/libgodot.iphone.opt.debug.fat ios_xcode/libgodot.iphone.debug.fat.a
-  chmod +x ios_xcode/libgodot.iphone.*
+  cp out/ios/templates/libgodot.iphone.simulator.a ios_xcode/libgodot.iphone.release.xcframework/ios-arm64_x86_64-simulator/libgodot.a
+  cp out/ios/templates/libgodot.iphone.debug.simulator.a ios_xcode/libgodot.iphone.debug.xcframework/ios-arm64_x86_64-simulator/libgodot.a
+  cp out/ios/templates/libgodot.iphone.a ios_xcode/libgodot.iphone.release.xcframework/ios-arm64/libgodot.a
+  cp out/ios/templates/libgodot.iphone.debug.a ios_xcode/libgodot.iphone.debug.xcframework/ios-arm64/libgodot.a
   cd ios_xcode
   zip -q -9 -r "${templatesdir}/iphone.zip" *
   cd ..
@@ -489,9 +490,10 @@ if [ "${build_mono}" == "1" ]; then
 
   rm -rf ios_xcode
   cp -r git/misc/dist/ios_xcode ios_xcode
-  cp out/ios/templates-mono/libgodot.iphone.opt.fat ios_xcode/libgodot.iphone.release.fat.a
-  cp out/ios/templates-mono/libgodot.iphone.opt.debug.fat ios_xcode/libgodot.iphone.debug.fat.a
-  chmod +x ios_xcode/libgodot.iphone.*
+  cp out/ios/templates-mono/libgodot.iphone.simulator.a ios_xcode/libgodot.iphone.release.xcframework/ios-arm64_x86_64-simulator/libgodot.a
+  cp out/ios/templates-mono/libgodot.iphone.debug.simulator.a ios_xcode/libgodot.iphone.debug.xcframework/ios-arm64_x86_64-simulator/libgodot.a
+  cp out/ios/templates-mono/libgodot.iphone.a ios_xcode/libgodot.iphone.release.xcframework/ios-arm64/libgodot.a
+  cp out/ios/templates-mono/libgodot.iphone.debug.a ios_xcode/libgodot.iphone.debug.xcframework/ios-arm64/libgodot.a
   cd ios_xcode
   zip -q -9 -r "${templatesdir_mono}/iphone.zip" *
   cd ..
@@ -499,8 +501,7 @@ if [ "${build_mono}" == "1" ]; then
 
   mkdir -p ${templatesdir_mono}/bcl
   cp -r out/ios/templates-mono/bcl/monotouch* ${templatesdir_mono}/bcl/
-
-  cp -r out/ios/templates-mono/iphone-mono-libs ${templatesdir_mono}/
+  cp -r out/ios/templates-mono/iphone-mono-libs ${templatesdir_mono}
 
   ## UWP (Mono) ##
 


### PR DESCRIPTION
Add ARM64 iOS simulator builds, and `.xcframework` creation.

Depends on https://github.com/godotengine/godot-mono-builds/pull/30 and https://github.com/godotengine/build-containers/pull/68