### PR TITLE
Mono 6.12.0.114, EMSDK values now defined in container

### DIFF
--- a/build-javascript/build.sh
+++ b/build-javascript/build.sh
@@ -9,8 +9,6 @@ export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="debug_symbols=no use_lto=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no"
 export TERM=xterm
-export EMSDK_CLASSICAL=2.0.10
-export EMSDK_MONO=1.39.9
 
 rm -rf godot
 mkdir godot

--- a/build.sh
+++ b/build.sh
@@ -163,7 +163,7 @@ mkdir -p ${basedir}/out
 mkdir -p ${basedir}/out/logs
 
 export podman_run="${podman} run -it --rm --env NUM_CORES --env CLASSICAL=${build_classical} --env MONO=${build_mono} -v ${basedir}/godot.tar.gz:/root/godot.tar.gz -v ${basedir}/mono-glue:/root/mono-glue -w /root/"
-export img_version=3.2-mono-6.12.0.111
+export img_version=3.2-mono-6.12.0.114
 
 # Get AOT compilers from their containers.
 mkdir -p ${basedir}/out/aot-compilers


### PR DESCRIPTION
Had this locally but forgot to PR.

Supersedes #15.