### PR TITLE
Use new production=yes option

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no"
+export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=no"
 export TERM=xterm
 

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -6,7 +6,9 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no"
+# Keep LTO disabled for iOS - it works but it makes linking apps on deploy very slow,
+# which is seen as a regression in the current workflow.
+export OPTIONS="production=yes use_lto=no"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 

--- a/build-javascript/build.sh
+++ b/build-javascript/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no use_lto=yes"
+export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no"
 export TERM=xterm
 

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no use_lto=yes"
+export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 

--- a/build-macosx/build.sh
+++ b/build-macosx/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="osxcross_sdk=darwin20 debug_symbols=no"
+export OPTIONS="osxcross_sdk=darwin20 production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/dependencies/mono"
 export TERM=xterm
 

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no"
+export OPTIONS="debug_symbols=no use_static_cpp=no"
 export TERM=xterm
 
 rm -rf godot

--- a/build-server/build.sh
+++ b/build-server/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no use_static_cpp=yes use_lto=yes"
+export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 export CC="gcc-9"

--- a/build-uwp/build.sh
+++ b/build-uwp/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="call scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no"
+export OPTIONS="production=yes"
 export BUILD_ARCHES="x86 x64 arm"
 export ANGLE_SRC_PATH='c:\angle'
 

--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="debug_symbols=no use_lto=yes"
+export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 export MONO32_PREFIX=/root/dependencies/mono-32


### PR DESCRIPTION
Equivalent to debug_symbols=no use_lto=yes use_static_cpp=yes.
We keep LTO disabled for iOS as users need to relink on deploy, and that's very slow
and memory hungry with LTO.