### PR TITLE
Mono/macOS: Change .app packaging and codesign editor binary

### DIFF
--- a/build-macosx/editor_mono.entitlements
+++ b/build-macosx/editor_mono.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+ <true/>
+ <key>com.apple.security.cs.allow-jit</key>
+ <true/>
+ <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+ <true/>
+ <key>com.apple.security.cs.disable-library-validation</key>
+ <true/>
+ <key>com.apple.security.device.audio-input</key>
+ <true/>
+ <key>com.apple.security.device.camera</key>
+ <true/>
+</dict>
+</plist>

--- a/build-release.sh
+++ b/build-release.sh
@@ -366,16 +366,10 @@ if [ "${build_mono}" == "1" ]; then
   binname="${godot_basename}_mono_osx.64"
   rm -rf Godot_mono.app
   cp -r git/misc/dist/osx_tools.app Godot_mono.app
-  mkdir -p Godot_mono.app/Contents/MacOS
+  mkdir -p Godot_mono.app/Contents/{MacOS,Resources}
   cp out/macosx/tools-mono/godot.osx.opt.tools.x86_64.mono Godot_mono.app/Contents/MacOS/Godot
-  mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}
-  mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp
-  mkdir -p Godot_mono.app/Contents/{Frameworks,Resources}/GodotSharp/Mono
-  cp -rp out/macosx/tools-mono/GodotSharp/Api Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/tools-mono/GodotSharp/Mono/lib Godot_mono.app/Contents/Frameworks/GodotSharp/Mono
-  cp -rp out/macosx/tools-mono/GodotSharp/Tools Godot_mono.app/Contents/Frameworks/GodotSharp
-  cp -rp out/macosx/tools-mono/GodotSharp/Mono/etc Godot_mono.app/Contents/Resources/GodotSharp/Mono
-  cp -rp out/aot-compilers Godot_mono.app/Contents/Frameworks/GodotSharp/Tools/
+  cp -rp out/macosx/tools-mono/GodotSharp Godot_mono.app/Contents/Resources/GodotSharp
+  cp -rp out/aot-compilers Godot_mono.app/Contents/Resources/GodotSharp/Tools/
   chmod +x Godot_mono.app/Contents/MacOS/Godot
   zip -q -9 -r "${reldir_mono}/${binname}.zip" Godot_mono.app
   rm -rf Godot_mono.app
@@ -383,11 +377,10 @@ if [ "${build_mono}" == "1" ]; then
   # Templates
   rm -rf osx_template.app
   cp -r git/misc/dist/osx_template.app .
-  mkdir -p osx_template.app/Contents/MacOS
-
+  mkdir -p osx_template.app/Contents/{MacOS,Resources}
   cp out/macosx/templates-mono/godot.osx.opt.debug.x86_64.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
   cp out/macosx/templates-mono/godot.osx.opt.x86_64.mono osx_template.app/Contents/MacOS/godot_osx_release.64
-  cp -rp out/macosx/templates-mono/data.mono.osx.64.* osx_template.app/Contents/MacOS/
+  cp -rp out/macosx/templates-mono/data.mono.osx.64.* osx_template.app/Contents/Resources/
   chmod +x osx_template.app/Contents/MacOS/godot_osx*
   zip -q -9 -r "${templatesdir_mono}/osx.zip" osx_template.app
   rm -rf osx_template.app

--- a/build-release.sh
+++ b/build-release.sh
@@ -14,12 +14,59 @@ else
   echo "Disabling binary signing as config.sh does not define the required data."
 fi
 
-function sign {
+sign_windows() {
   if [ $can_sign == 0 ]; then
     return
   fi
   ./osslsigncode -pkcs12 ${SIGN_KEYSTORE} -pass "${SIGN_PASSWORD}" -n "${SIGN_NAME}" -i "${SIGN_URL}" -t http://timestamp.comodoca.com -in $1 -out $1-signed
   mv $1-signed $1
+}
+
+sign_macos() {
+  if [ ! -z "${OSX_HOST}" ]; then
+    osx_tmpdir=$(ssh "${OSX_HOST}" "mktemp -d")
+    reldir="$1"
+    binname="$2"
+    is_mono="$3"
+
+    if [[ "${is_mono}" == "1" ]]; then
+      appname="Godot_mono.app"
+      entitlements=editor_mono.entitlements
+      sharpdir="${appname}/Contents/Resources/GodotSharp"
+      extra_files="${sharpdir}/Mono/lib/*.dylib ${sharpdir}/Tools/aot-compilers/*/*"
+    else
+      appname="Godot.app"
+      entitlements=editor.entitlements
+    fi
+
+    scp "${reldir}/${binname}.zip" "${OSX_HOST}:${osx_tmpdir}"
+    scp "${basedir}/build-macosx/${entitlements}" "${OSX_HOST}:${osx_tmpdir}"
+    ssh "${OSX_HOST}" "
+              cd ${osx_tmpdir} && \
+              unzip ${binname}.zip && \
+              codesign --force --timestamp \
+                --options=runtime --entitlements ${entitlements} \
+                -s ${OSX_KEY_ID} -v ${extra_files} ${appname} && \
+              zip -r ${binname}_signed.zip ${appname}"
+
+    request_uuid=$(ssh "${OSX_HOST}" "xcrun altool --notarize-app --primary-bundle-id \"${OSX_BUNDLE_ID}\" --username \"${APPLE_ID}\" --password \"${APPLE_ID_PASSWORD}\" --file ${osx_tmpdir}/${binname}_signed.zip")
+    request_uuid=$(echo ${request_uuid} | sed -e 's/.*RequestUUID = //')
+    ssh "${OSX_HOST}" "while xcrun altool --notarization-history 0 -u \"${APPLE_ID}\" -p \"${APPLE_ID_PASSWORD}\" | grep -q ${request_uuid}.*in\ progress; do echo Waiting on Apple notarization...; sleep 30s; done"
+    if ! ssh "${OSX_HOST}" "xcrun altool --notarization-history 0 -u \"${APPLE_ID}\" -p \"${APPLE_ID_PASSWORD}\" | grep -q ${request_uuid}.*success"; then
+      echo "Notarization failed."
+      notarization_log=$(ssh "${OSX_HOST}" "xcrun altool --notarization-info ${request_uuid} -u \"${APPLE_ID}\" -p \"${APPLE_ID_PASSWORD}\"")
+      echo "${notarization_log}"
+      ssh "${OSX_HOST}" "rm -rf ${osx_tmpdir}"
+      exit 1
+    else
+      ssh "${OSX_HOST}" "
+              cd ${osx_tmpdir} && \
+              xcrun stapler staple ${appname} && \
+              zip -r ${binname}_stapled.zip ${appname}"
+      scp "${OSX_HOST}:${osx_tmpdir}/${binname}_stapled.zip" ${reldir}/${binname}.zip
+      ssh "${OSX_HOST}" "rm -rf ${osx_tmpdir}"
+    fi
+  fi
 }
 
 godot_version=""
@@ -117,14 +164,14 @@ if [ "${build_classical}" == "1" ]; then
   binname="${godot_basename}_win64.exe"
   cp out/windows/x64/tools/godot.windows.opt.tools.64.exe ${binname}
   strip ${binname}
-  sign ${binname}
+  sign_windows ${binname}
   zip -q -9 "${reldir}/${binname}.zip" ${binname}
   rm ${binname}
 
   binname="${godot_basename}_win32.exe"
   cp out/windows/x86/tools/godot.windows.opt.tools.32.exe ${binname}
   strip ${binname}
-  sign ${binname}
+  sign_windows ${binname}
   zip -q -9 "${reldir}/${binname}.zip" ${binname}
   rm ${binname}
 
@@ -147,34 +194,7 @@ if [ "${build_classical}" == "1" ]; then
   chmod +x Godot.app/Contents/MacOS/Godot
   zip -q -9 -r "${reldir}/${binname}.zip" Godot.app
   rm -rf Godot.app
-
-  if [ ! -z "${OSX_HOST}" ]; then
-    osx_tmpdir=$(ssh "${OSX_HOST}" "mktemp -d")
-    
-    scp "${reldir}/${binname}.zip" "${OSX_HOST}:${osx_tmpdir}"
-    scp "${basedir}/build-macosx/editor.entitlements" "${OSX_HOST}:${osx_tmpdir}"
-    ssh "${OSX_HOST}" "
-              cd ${osx_tmpdir} && \
-              unzip ${binname}.zip &&\
-              codesign --timestamp --options=runtime --entitlements editor.entitlements -s ${OSX_KEY_ID} -v Godot.app/Contents/MacOS/Godot && \
-              zip -r ${binname}_signed.zip Godot.app"
-    
-    request_uuid=$(ssh "${OSX_HOST}" "xcrun altool --notarize-app --primary-bundle-id \"${OSX_BUNDLE_ID}\" --username \"${APPLE_ID}\" --password \"${APPLE_ID_PASSWORD}\" --file ${osx_tmpdir}/${binname}_signed.zip")
-    request_uuid=$(echo ${request_uuid} | sed -e 's/.*RequestUUID = //')
-    ssh "${OSX_HOST}" "while xcrun altool --notarization-history 0 -u \"${APPLE_ID}\" -p \"${APPLE_ID_PASSWORD}\" | grep -q ${request_uuid}.*in\ progress; do echo Waiting on Apple signature; sleep 30s; done"
-    if ! ssh "${OSX_HOST}" "xcrun altool --notarization-history 0 -u \"${APPLE_ID}\" -p \"${APPLE_ID_PASSWORD}\" | grep -q ${request_uuid}.*success"; then
-      echo "Signing failed?"
-      ssh "${OSX_HOST}" "rm -rf ${osx_tmpdir}"
-      exit 1
-    else
-      ssh "${OSX_HOST}" "
-              cd ${osx_tmpdir} && \
-              xcrun stapler staple Godot.app && \
-              zip -r ${binname}_stapled.zip Godot.app"
-      scp "${OSX_HOST}:${osx_tmpdir}/${binname}_stapled.zip" ${reldir}/${binname}.zip
-      ssh "${OSX_HOST}" "rm -rf ${osx_tmpdir}"
-    fi
-  fi
+  sign_macos ${reldir} ${binname} 0
 
   # Templates
   rm -rf osx_template.app
@@ -373,6 +393,7 @@ if [ "${build_mono}" == "1" ]; then
   chmod +x Godot_mono.app/Contents/MacOS/Godot
   zip -q -9 -r "${reldir_mono}/${binname}.zip" Godot_mono.app
   rm -rf Godot_mono.app
+  sign_macos ${reldir_mono} ${binname} 1
 
   # Templates
   rm -rf osx_template.app


### PR DESCRIPTION
Supersedes #13, thanks @sjml for the initial work and @neikeq for the buildsystem changes.

Requires https://github.com/godotengine/godot/pull/43768 to be cherry-picking in `3.2` to work.

---

Marking as draft but it's ready for review, it's just until https://github.com/godotengine/godot/pull/43768 is merged and cherry-picked and the resulting binaries are tested.