### PR TITLE
Make `BUILD_NAME` globally configurable

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=no"

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 # Keep LTO disabled for iOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.

--- a/build-javascript/build.sh
+++ b/build-javascript/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no"

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"

--- a/build-macosx/build.sh
+++ b/build-macosx/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="osxcross_sdk=darwin20 production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/dependencies/mono"

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="debug_symbols=no use_static_cpp=no"
 export TERM=xterm

--- a/build-server/build.sh
+++ b/build-server/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"

--- a/build-uwp/build.sh
+++ b/build-uwp/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="call scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export BUILD_ARCHES="x86 x64 arm"

--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -4,7 +4,6 @@ set -e
 
 # Config
 
-export BUILD_NAME=official
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,10 @@ if [ ! -e config.sh ]; then
 fi
 source ./config.sh
 
+if [ -z "${BUILD_NAME}" ]; then
+  export BUILD_NAME="custom_build"
+fi
+
 if [ -z "${NUM_CORES}" ]; then
   export NUM_CORES=16
 fi
@@ -162,7 +166,7 @@ export basedir="$(pwd)"
 mkdir -p ${basedir}/out
 mkdir -p ${basedir}/out/logs
 
-export podman_run="${podman} run -it --rm --env NUM_CORES --env CLASSICAL=${build_classical} --env MONO=${build_mono} -v ${basedir}/godot.tar.gz:/root/godot.tar.gz -v ${basedir}/mono-glue:/root/mono-glue -w /root/"
+export podman_run="${podman} run -it --rm --env BUILD_NAME --env NUM_CORES --env CLASSICAL=${build_classical} --env MONO=${build_mono} -v ${basedir}/godot.tar.gz:/root/godot.tar.gz -v ${basedir}/mono-glue:/root/mono-glue -w /root/"
 export img_version=3.2-mono-6.12.0.114
 
 # Get AOT compilers from their containers.

--- a/config.sh.in
+++ b/config.sh.in
@@ -11,6 +11,9 @@
 # https://github.com/godotengine/build-containers
 export REGISTRY="registry.prehensile-tales.com"
 
+# Default build name used to distinguish between official and custom builds.
+export BUILD_NAME="custom_build"
+
 # Default number of parallel cores for each build.
 export NUM_CORES=16
 


### PR DESCRIPTION
Makes it easier to distinguish between official and custom builds by allowing developers to customize `BUILD_NAME` env var.

I can make it to default to `custom_build` over `official` if you like. Of course, nothing prevents someone to use `official` name, but this will decrease the likelihood of someone compiling the editor and export templates as official, otherwise the only way to distinguish such builds is by using checksums.

Also note that `BUILD_NAME` can be fetched at run-time via script with [`Engine.get_version_info()`](https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info).