### PR TITLE
Add `angle.7z` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ angle/
 git/
 mono-glue/
 godot.tar.gz
+angle.7z
 
 # Output
 out/


### PR DESCRIPTION
Note: at first I thought that it's simply not `.gitignore`d, but then I've noticed `angle` is there, but when I ran `build_release.sh`, it ended up in repository root, so makes me wonder whether it's a bug. I've prematurely made the PR instead of creating an issue about this so feel free to close this PR and fix the underlying issue, but I think merging this won't hurt anything anyways.

Here's the code:
https://github.com/godotengine/godot-build-scripts/blob/f3a5097159933becc1df63f0b6c567c2ff4830fa/build-release.sh#L263-L267