### PR TITLE
Use images version 3.x-mono-6.12.0.122

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -11,7 +11,7 @@ export OPTIONS="production=yes use_lto=no"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 
-export IOS_SDK="14.2"
+export IOS_SDK="14.4"
 export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
 
 rm -rf godot

--- a/build-macosx/build.sh
+++ b/build-macosx/build.sh
@@ -5,12 +5,10 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="osxcross_sdk=darwin20 production=yes"
+export OPTIONS="osxcross_sdk=darwin20.2 production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/dependencies/mono"
 export TERM=xterm
-export STRIP="x86_64-apple-darwin20-strip -u -r"
-# Disable fake-signing of arm binaries.
-export NO_LDID=1
+export STRIP="x86_64-apple-darwin20.2-strip -u -r"
 
 rm -rf godot
 mkdir godot

--- a/build.sh
+++ b/build.sh
@@ -167,7 +167,7 @@ mkdir -p ${basedir}/out
 mkdir -p ${basedir}/out/logs
 
 export podman_run="${podman} run -it --rm --env BUILD_NAME --env NUM_CORES --env CLASSICAL=${build_classical} --env MONO=${build_mono} -v ${basedir}/godot.tar.gz:/root/godot.tar.gz -v ${basedir}/mono-glue:/root/mono-glue -w /root/"
-export img_version=3.2-mono-6.12.0.114
+export img_version=3.x-mono-6.12.0.122
 
 # Get AOT compilers from their containers.
 mkdir -p ${basedir}/out/aot-compilers


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/build-containers/pull/77.

OSX/iOS: Now using Xcode 12.4 and newer osxcross
`NO_LDID` no longer needed as osxcross is no longer fake-signing with LDID.