### PR TITLE
Update scripts for overhauled build containers (`3.x-mono-6.12.0.147`)

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -7,15 +7,9 @@ set -e
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
+export MONO_PREFIX_X86_64="/root/mono-installs/desktop-linux-x86_64-release"
+export MONO_PREFIX_X86="/root/mono-installs/desktop-linux-x86-release"
 export TERM=xterm
-
-# For i386 we're still using an old GCC 5 version from Ubuntu 16.04 as
-# upgrading the compiler seems to introduce weird issues.
-# Since that GCC version is fairly old, let's avoid LTO which wasn't so
-# mature at the time.
-if [ "$(getconf LONG_BIT)" == "32" ]; then
-  export OPTIONS="$OPTIONS use_lto=no"
-fi
 
 rm -rf godot
 mkdir godot
@@ -27,15 +21,30 @@ tar xf /root/godot.tar.gz --strip-components=1
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for Linux..."
 
+  export PATH="${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH}"
+
   $SCONS platform=x11 $OPTIONS tools=yes target=release_debug
-  mkdir -p /root/out/tools
-  cp -rvp bin/* /root/out/tools
+  mkdir -p /root/out/x64/tools
+  cp -rvp bin/* /root/out/x64/tools
   rm -rf bin
 
   $SCONS platform=x11 $OPTIONS tools=no target=release_debug
   $SCONS platform=x11 $OPTIONS tools=no target=release
-  mkdir -p /root/out/templates
-  cp -rvp bin/* /root/out/templates
+  mkdir -p /root/out/x64/templates
+  cp -rvp bin/* /root/out/x64/templates
+  rm -rf bin
+
+  export PATH="${GODOT_SDK_LINUX_X86}/bin:${BASE_PATH}"
+
+  $SCONS platform=x11 $OPTIONS tools=yes target=release_debug bits=32
+  mkdir -p /root/out/x86/tools
+  cp -rvp bin/* /root/out/x86/tools
+  rm -rf bin
+
+  $SCONS platform=x11 $OPTIONS tools=no target=release_debug bits=32
+  $SCONS platform=x11 $OPTIONS tools=no target=release bits=32
+  mkdir -p /root/out/x86/templates
+  cp -rvp bin/* /root/out/x86/templates
   rm -rf bin
 fi
 
@@ -47,21 +56,33 @@ if [ "${MONO}" == "1" ]; then
   cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
-  export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
 
-  # Workaround for MSBuild segfault on Ubuntu containers, we build the CIL on Fedora and copy here.
-  mkdir -p bin
-  cp -r /root/mono-glue/cil/GodotSharp bin/
+  export PATH="${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH}"
+  export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86_64}"
 
-  $SCONS platform=x11 $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes build_cil=no
-  mkdir -p /root/out/tools-mono
-  cp -rvp bin/* /root/out/tools-mono
+  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  mkdir -p /root/out/x64/tools-mono
+  cp -rvp bin/* /root/out/x64/tools-mono
   rm -rf bin
 
-  $SCONS platform=x11 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
-  $SCONS platform=x11 $OPTIONS $OPTIONS_MONO tools=no target=release
-  mkdir -p /root/out/templates-mono
-  cp -rvp bin/* /root/out/templates-mono
+  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=no target=release_debug
+  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=no target=release
+  mkdir -p /root/out/x64/templates-mono
+  cp -rvp bin/* /root/out/x64/templates-mono
+  rm -rf bin
+
+  export PATH="${GODOT_SDK_LINUX_X86}/bin:${BASE_PATH}"
+  export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86}"
+
+  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes bits=32
+  mkdir -p /root/out/x86/tools-mono
+  cp -rvp bin/* /root/out/x86/tools-mono
+  rm -rf bin
+
+  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=no target=release_debug bits=32
+  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=no target=release bits=32
+  mkdir -p /root/out/x86/templates-mono
+  cp -rvp bin/* /root/out/x86/templates-mono
   rm -rf bin
 fi
 

--- a/build-macosx/build.sh
+++ b/build-macosx/build.sh
@@ -6,9 +6,11 @@ set -e
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="osxcross_sdk=darwin20.2 production=yes"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/dependencies/mono"
-export TERM=xterm
+export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
+export MONO_PREFIX_X86_64="/root/mono-installs/desktop-osx-x86_64-release"
+export MONO_PREFIX_ARM64="/root/mono-installs/desktop-osx-arm64-release"
 export STRIP="x86_64-apple-darwin20.2-strip -u -r"
+export TERM=xterm
 
 rm -rf godot
 mkdir godot
@@ -52,26 +54,43 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
-  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=x86_64 tools=yes target=release_debug copy_mono_root=yes
-  $STRIP bin/godot.osx.opt.tools.x86_64.mono
-  #$SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=arm64 tools=yes target=release_debug copy_mono_root=yes
-  #lipo -create bin/godot.osx.opt.tools.x86_64.mono bin/godot.osx.opt.tools.arm64.mono -output bin/godot.osx.opt.tools.universal.mono
-  #$STRIP bin/godot.osx.opt.tools.universal.mono
+  # Note: A bit of dylib wrangling involved as x86_64 and arm64 builds both generate GodotSharp
+  # so the second build overrides the first, but we need to lipo the libs to make them universal.
+  # We also need to ensure that /etc/mono/config has the proper filenames (keep arm64 as the last
+  # build so that we rely on its config, which has libmono-native.dylib instead of
+  # libmono-native-compat.dylib).
+  mkdir -p tmp-lib/{x86_64,arm64}
+
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO mono_prefix=$MONO_PREFIX_X86_64 arch=x86_64 tools=yes target=release_debug copy_mono_root=yes
+  cp bin/GodotSharp/Mono/lib/*.dylib tmp-lib/x86_64/
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO mono_prefix=$MONO_PREFIX_ARM64 arch=arm64 tools=yes target=release_debug copy_mono_root=yes
+  cp bin/GodotSharp/Mono/lib/*.dylib tmp-lib/arm64/
+  lipo -create bin/godot.osx.opt.tools.x86_64.mono bin/godot.osx.opt.tools.arm64.mono -output bin/godot.osx.opt.tools.universal.mono
+  $STRIP bin/godot.osx.opt.tools.universal.mono
+
+  # Make universal versions of the dylibs we use.
+  lipo -create tmp-lib/x86_64/libmono-native-compat.dylib tmp-lib/arm64/libmono-native.dylib -output tmp-lib/libmono-native.dylib
+  lipo -create tmp-lib/x86_64/libMonoPosixHelper.dylib tmp-lib/arm64/libMonoPosixHelper.dylib -output tmp-lib/libMonoPosixHelper.dylib
+  # Somehow only included in x86_64 build.
+  cp tmp-lib/x86_64/libmono-btls-shared.dylib tmp-lib/
+
+  cp -f tmp-lib/*.dylib bin/GodotSharp/Mono/lib/
 
   mkdir -p /root/out/tools-mono
   cp -rvp bin/* /root/out/tools-mono
   rm -rf bin
 
-  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=x86_64 tools=no target=release_debug
-  $STRIP bin/godot.osx.opt.debug.x86_64.mono
-  #$SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=arm64 tools=no target=release_debug
-  #lipo -create bin/godot.osx.opt.debug.x86_64.mono bin/godot.osx.opt.debug.arm64.mono -output bin/godot.osx.opt.debug.universal.mono
-  #$STRIP bin/godot.osx.opt.debug.universal.mono
-  $SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=x86_64 tools=no target=release
-  $STRIP bin/godot.osx.opt.x86_64.mono
-  #$SCONS platform=osx $OPTIONS $OPTIONS_MONO arch=arm64 tools=no target=release
-  #lipo -create bin/godot.osx.opt.x86_64.mono bin/godot.osx.opt.arm64.mono -output bin/godot.osx.opt.universal.mono
-  #$STRIP bin/godot.osx.opt.universal.mono
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO mono_prefix=$MONO_PREFIX_X86_64 arch=x86_64 tools=no target=release_debug
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO mono_prefix=$MONO_PREFIX_ARM64 arch=arm64 tools=no target=release_debug
+  lipo -create bin/godot.osx.opt.debug.x86_64.mono bin/godot.osx.opt.debug.arm64.mono -output bin/godot.osx.opt.debug.universal.mono
+  $STRIP bin/godot.osx.opt.debug.universal.mono
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO mono_prefix=$MONO_PREFIX_X86_64 arch=x86_64 tools=no target=release
+  $SCONS platform=osx $OPTIONS $OPTIONS_MONO mono_prefix=$MONO_PREFIX_ARM64 arch=arm64 tools=no target=release
+  lipo -create bin/godot.osx.opt.x86_64.mono bin/godot.osx.opt.arm64.mono -output bin/godot.osx.opt.universal.mono
+  $STRIP bin/godot.osx.opt.universal.mono
+
+  cp -f tmp-lib/*.dylib bin/data.mono.osx.64.release/Mono/lib/
+  cp -f tmp-lib/*.dylib bin/data.mono.osx.64.release_debug/Mono/lib/
 
   mkdir -p /root/out/templates-mono
   cp -rvp bin/* /root/out/templates-mono

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -26,14 +26,6 @@ if [ "${MONO}" == "1" ]; then
 
   rm -rf /root/mono-glue/*
   xvfb-run bin/godot.x11.opt.tools.64.mono --audio-driver Dummy --generate-mono-glue /root/mono-glue || /bin/true
-
-  # Build and copy CIL that we'll need for Ubuntu 14.04 Linux builds
-  # to workaround Mono MSBuild segfault in our containers.
-  xvfb-run bin/godot.x11.opt.tools.64.mono --audio-driver Dummy --generate-mono-glue modules/mono/glue || /bin/true
-  ${SCONS} platform=x11 bits=64 ${OPTIONS} target=release_debug tools=yes module_mono_enabled=yes mono_glue=yes build_cil=yes
-
-  mkdir /root/mono-glue/cil
-  cp -r bin/GodotSharp /root/mono-glue/cil/
 fi
 
 echo "Mono glue generated successfully"

--- a/build-release.sh
+++ b/build-release.sh
@@ -419,11 +419,11 @@ if [ "${build_mono}" == "1" ]; then
   ## OSX (Mono) ##
 
   # Editor
-  binname="${godot_basename}_mono_osx.64"
+  binname="${godot_basename}_mono_osx.universal"
   rm -rf Godot_mono.app
   cp -r git/misc/dist/osx_tools.app Godot_mono.app
   mkdir -p Godot_mono.app/Contents/{MacOS,Resources}
-  cp out/macosx/tools-mono/godot.osx.opt.tools.x86_64.mono Godot_mono.app/Contents/MacOS/Godot
+  cp out/macosx/tools-mono/godot.osx.opt.tools.universal.mono Godot_mono.app/Contents/MacOS/Godot
   cp -rp out/macosx/tools-mono/GodotSharp Godot_mono.app/Contents/Resources/GodotSharp
   cp -rp out/aot-compilers Godot_mono.app/Contents/Resources/GodotSharp/Tools/
   chmod +x Godot_mono.app/Contents/MacOS/Godot
@@ -435,8 +435,8 @@ if [ "${build_mono}" == "1" ]; then
   rm -rf osx_template.app
   cp -r git/misc/dist/osx_template.app .
   mkdir -p osx_template.app/Contents/{MacOS,Resources}
-  cp out/macosx/templates-mono/godot.osx.opt.debug.x86_64.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
-  cp out/macosx/templates-mono/godot.osx.opt.x86_64.mono osx_template.app/Contents/MacOS/godot_osx_release.64
+  cp out/macosx/templates-mono/godot.osx.opt.debug.universal.mono osx_template.app/Contents/MacOS/godot_osx_debug.64
+  cp out/macosx/templates-mono/godot.osx.opt.universal.mono osx_template.app/Contents/MacOS/godot_osx_release.64
   cp -rp out/macosx/templates-mono/data.mono.osx.64.* osx_template.app/Contents/Resources/
   chmod +x osx_template.app/Contents/MacOS/godot_osx*
   zip -q -9 -r "${templatesdir_mono}/osx.zip" osx_template.app

--- a/build-server/build.sh
+++ b/build-server/build.sh
@@ -6,10 +6,9 @@ set -e
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
+export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/desktop-linux-x86_64-release"
 export TERM=xterm
-export CC="gcc-9"
-export CXX="g++-9"
+export PATH="${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH}"
 
 rm -rf godot
 mkdir godot
@@ -21,15 +20,14 @@ tar xf /root/godot.tar.gz --strip-components=1
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for Server..."
 
-  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=yes target=release_debug
-  mkdir -p /root/out/tools
-  cp -rvp bin/* /root/out/tools
+  $SCONS platform=server $OPTIONS tools=yes target=release_debug
+  mkdir -p /root/out/x64/tools
+  cp -rvp bin/* /root/out/x64/tools
   rm -rf bin
 
-  #$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=no target=release_debug
-  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS tools=no target=release
-  mkdir -p /root/out/templates
-  cp -rvp bin/* /root/out/templates
+  $SCONS platform=server $OPTIONS tools=no target=release
+  mkdir -p /root/out/x64/templates
+  cp -rvp bin/* /root/out/x64/templates
   rm -rf bin
 fi
 
@@ -42,19 +40,14 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
-  # Workaround for MSBuild segfault on Ubuntu containers, we build the CIL on Fedora and copy here.
-  mkdir -p bin
-  cp -r /root/mono-glue/cil/GodotSharp bin/
-
-  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes build_cil=no
-  mkdir -p /root/out/tools-mono
-  cp -rvp bin/* /root/out/tools-mono
+  $SCONS platform=server $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
+  mkdir -p /root/out/x64/tools-mono
+  cp -rvp bin/* /root/out/x64/tools-mono
   rm -rf bin
 
-  #$SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release_debug
-  $SCONS platform=server CC=$CC CXX=$CXX $OPTIONS $OPTIONS_MONO tools=no target=release
-  mkdir -p /root/out/templates-mono
-  cp -rvp bin/* /root/out/templates-mono
+  $SCONS platform=server $OPTIONS $OPTIONS_MONO tools=no target=release
+  mkdir -p /root/out/x64/templates-mono
+  cp -rvp bin/* /root/out/x64/templates-mono
   rm -rf bin
 fi
 

--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -7,9 +7,9 @@ set -e
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
+export MONO_PREFIX_X86_64="/root/mono-installs/desktop-windows-x86_64-release"
+export MONO_PREFIX_X86="/root/mono-installs/desktop-windows-x86-release"
 export TERM=xterm
-export MONO32_PREFIX=/root/dependencies/mono-32
-export MONO64_PREFIX=/root/dependencies/mono-64
 
 rm -rf godot
 mkdir godot
@@ -53,24 +53,28 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
-  $SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86_64}"
+
+  $SCONS platform=windows bits=64 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
   mkdir -p /root/out/x64/tools-mono
   cp -rvp bin/* /root/out/x64/tools-mono
   rm -rf bin
 
-  $SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=no target=release_debug
-  $SCONS platform=windows bits=64 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO64_PREFIX tools=no target=release
+  $SCONS platform=windows bits=64 $OPTIONS_MONO_PREFIX tools=no target=release_debug
+  $SCONS platform=windows bits=64 $OPTIONS_MONO_PREFIX tools=no target=release
   mkdir -p /root/out/x64/templates-mono
   cp -rvp bin/* /root/out/x64/templates-mono
   rm -rf bin
 
-  $SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86}"
+
+  $SCONS platform=windows bits=32 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
   mkdir -p /root/out/x86/tools-mono
   cp -rvp bin/* /root/out/x86/tools-mono
   rm -rf bin
 
-  $SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=no target=release_debug
-  $SCONS platform=windows bits=32 $OPTIONS $OPTIONS_MONO mono_prefix=$MONO32_PREFIX tools=no target=release
+  $SCONS platform=windows bits=32 $OPTIONS_MONO_PREFIX tools=no target=release_debug
+  $SCONS platform=windows bits=32 $OPTIONS_MONO_PREFIX tools=no target=release
   mkdir -p /root/out/x86/templates-mono
   cp -rvp bin/* /root/out/x86/templates-mono
   rm -rf bin

--- a/build.sh
+++ b/build.sh
@@ -112,7 +112,7 @@ fi
 
 if [ $skip_download == 0 ]; then
   echo "Fetching images"
-  for image in mono-glue windows ubuntu-64 ubuntu-32 javascript; do
+  for image in mono-glue windows linux javascript; do
     if [ ${force_download} == 1 ] || ! ${podman} image exists godot/$image; then
       if ! ${podman} pull ${registry}/godot/${image}; then
         echo "ERROR: image $image does not exist and can't be downloaded"
@@ -167,7 +167,7 @@ mkdir -p ${basedir}/out
 mkdir -p ${basedir}/out/logs
 
 export podman_run="${podman} run -it --rm --env BUILD_NAME --env NUM_CORES --env CLASSICAL=${build_classical} --env MONO=${build_mono} -v ${basedir}/godot.tar.gz:/root/godot.tar.gz -v ${basedir}/mono-glue:/root/mono-glue -w /root/"
-export img_version=3.x-mono-6.12.0.122
+export img_version=3.x-mono-6.12.0.147
 
 # Get AOT compilers from their containers.
 mkdir -p ${basedir}/out/aot-compilers
@@ -180,11 +180,8 @@ ${podman_run} -v ${basedir}/build-mono-glue:/root/build localhost/godot-mono-glu
 mkdir -p ${basedir}/out/windows
 ${podman_run} -v ${basedir}/build-windows:/root/build -v ${basedir}/out/windows:/root/out localhost/godot-windows:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/windows
 
-mkdir -p ${basedir}/out/linux/x64
-${podman_run} -v ${basedir}/build-linux:/root/build -v ${basedir}/out/linux/x64:/root/out localhost/godot-ubuntu-64:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/linux64
-
-mkdir -p ${basedir}/out/linux/x86
-${podman_run} -v ${basedir}/build-linux:/root/build -v ${basedir}/out/linux/x86:/root/out localhost/godot-ubuntu-32:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/linux32
+mkdir -p ${basedir}/out/linux
+${podman_run} -v ${basedir}/build-linux:/root/build -v ${basedir}/out/linux:/root/out localhost/godot-linux:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/linux
 
 mkdir -p ${basedir}/out/javascript
 ${podman_run} -v ${basedir}/build-javascript:/root/build -v ${basedir}/out/javascript:/root/out localhost/godot-javascript:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/javascript
@@ -198,8 +195,8 @@ ${podman_run} -v ${basedir}/build-android:/root/build -v ${basedir}/out/android:
 mkdir -p ${basedir}/out/ios
 ${podman_run} -v ${basedir}/build-ios:/root/build -v ${basedir}/out/ios:/root/out localhost/godot-ios:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/ios
 
-mkdir -p ${basedir}/out/server/x64
-${podman_run} -v ${basedir}/build-server:/root/build -v ${basedir}/out/server/x64:/root/out localhost/godot-ubuntu-64:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/server
+mkdir -p ${basedir}/out/server
+${podman_run} -v ${basedir}/build-server:/root/build -v ${basedir}/out/server:/root/out localhost/godot-linux:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/server
 
 mkdir -p ${basedir}/out/uwp
 ${podman_run} --ulimit nofile=32768:32768 -v ${basedir}/build-uwp:/root/build -v ${basedir}/out/uwp:/root/out ${registry}/godot-private/uwp:latest bash build/build.sh 2>&1 | tee ${basedir}/out/logs/uwp


### PR DESCRIPTION
Cf. godotengine/build-containers#84

- Linux builds are now done on Fedora using a custom Godot SDK instead of
  relying on an old Ubuntu version for portability.
  Removes need for various workarounds.
- macOS Mono builds now include support for Apple Silicon / arm64, both
  architectures are concatenated in universal binaries.

This new config is compatible with the `3.x` branch for Godot 3.4.
It might or might not work as is for `master` / Godot 4.0. Porting it will
be the next step.

---

Also includes #41, will rebase once merged.