### PR TITLE
Add support for a preset godot directory

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -9,10 +9,15 @@ export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=no"
 export TERM=xterm
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf /root/godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 dnf install -y java-11-openjdk-devel
 java --version

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -14,10 +14,15 @@ export TERM=xterm
 export IOS_SDK="14.4"
 export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf /root/godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 # Classical
 

--- a/build-javascript/build.sh
+++ b/build-javascript/build.sh
@@ -9,10 +9,15 @@ export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no"
 export TERM=xterm
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf /root/godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 # Classical
 

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -11,10 +11,15 @@ export MONO_PREFIX_X86_64="/root/mono-installs/desktop-linux-x86_64-release"
 export MONO_PREFIX_X86="/root/mono-installs/desktop-linux-x86-release"
 export TERM=xterm
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf /root/godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 # Classical
 

--- a/build-macosx/build.sh
+++ b/build-macosx/build.sh
@@ -12,10 +12,15 @@ export MONO_PREFIX_ARM64="/root/mono-installs/desktop-osx-arm64-release"
 export STRIP="x86_64-apple-darwin20.2-strip -u -r"
 export TERM=xterm
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf /root/godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 # Classical
 

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -9,10 +9,15 @@ export OPTIONS="debug_symbols=no use_static_cpp=no"
 export TERM=xterm
 export DISPLAY=:0
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf ../godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 # Mono
 

--- a/build-server/build.sh
+++ b/build-server/build.sh
@@ -10,10 +10,15 @@ export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/m
 export TERM=xterm
 export PATH="${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH}"
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf /root/godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 # Classical
 

--- a/build-uwp/build.sh
+++ b/build-uwp/build.sh
@@ -9,10 +9,15 @@ export OPTIONS="production=yes"
 export BUILD_ARCHES="x86 x64 arm"
 export ANGLE_SRC_PATH='c:\angle'
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf /root/godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 # Classical
 

--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -11,10 +11,15 @@ export MONO_PREFIX_X86_64="/root/mono-installs/desktop-windows-x86_64-release"
 export MONO_PREFIX_X86="/root/mono-installs/desktop-windows-x86-release"
 export TERM=xterm
 
-rm -rf godot
-mkdir godot
-cd godot
-tar xf /root/godot.tar.gz --strip-components=1
+if [ ! -z "${PRESET_GODOT_DIR}" ]; then
+  cd $PRESET_GODOT_DIR
+  rm -rf bin
+else
+  rm -rf godot
+  mkdir godot
+  cd godot
+  tar xf /root/godot.tar.gz --strip-components=1
+fi
 
 # Classical
 


### PR DESCRIPTION
This way the builds will happen in the same directory, which is external to the running container, and the copying of godot's zip will be avoided.

This also makes it easier to perform a build with custom code.

By default the scripts will continue to work as they have been.

If this pull request is accepted, I may present other changes to improve the versatility of the build scripts. If that is not wanted of if the people managing this project feel like this is not the proper way to do that, please tell me and I will not make any pull requests and keep my changes in my own fork.

Best regards!