### PR TITLE
[Linux] Add armhf build.

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -47,6 +47,19 @@ if [ "${CLASSICAL}" == "1" ]; then
   mkdir -p /root/out/x86_32/templates
   cp -rvp bin/* /root/out/x86_32/templates
   rm -rf bin
+
+  export PATH="${GODOT_SDK_LINUX_ARMHF}/bin:${BASE_PATH}"
+
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS target=editor
+  mkdir -p /root/out/arm32/tools
+  cp -rvp bin/* /root/out/arm32/tools
+  rm -rf bin
+
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS target=template_debug
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS target=template_release
+  mkdir -p /root/out/arm32/templates
+  cp -rvp bin/* /root/out/arm32/templates
+  rm -rf bin
 fi
 
 # Mono


### PR DESCRIPTION
*EDIT*: Rebased, updated to use the new `arch` scons option, and removed the special `*_module_enabled=no` which are no longer necessary.

<details><summary>Original message</summary>
<p>

Some modules are disabled due to incompatibilities:
- raycast (embree), we should fix detecetion in module config.py.
- etcpak, this likely also require at least aarch64 instructions to build.
- denoise (oneDNN), also needs fix in config.py (x86_64 only).
- theora (are we keeping this?).

We should probably wait and instead of merging this PR directly, wait for https://github.com/godotengine/godot/pull/55778 or a light-weight version of it that fixes module detection (so we don't need the extra `*_module_enabled=no` shenanigan).

Depends on https://github.com/godotengine/build-containers/pull/103
Ref https://github.com/godotengine/godot-proposals/issues/988

</p>
</details> 