### PR TITLE
CPU architecture name changes for Windows/Linux outputs from SCons

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -26,26 +26,26 @@ if [ "${CLASSICAL}" == "1" ]; then
 
   export PATH="${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH}"
 
-  $SCONS platform=linuxbsd $OPTIONS tools=yes target=release_debug
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS tools=yes target=release_debug
   mkdir -p /root/out/x86_64/tools
   cp -rvp bin/* /root/out/x86_64/tools
   rm -rf bin
 
-  $SCONS platform=linuxbsd $OPTIONS tools=no target=release_debug
-  $SCONS platform=linuxbsd $OPTIONS tools=no target=release
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS tools=no target=release_debug
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS tools=no target=release
   mkdir -p /root/out/x86_64/templates
   cp -rvp bin/* /root/out/x86_64/templates
   rm -rf bin
 
   export PATH="${GODOT_SDK_LINUX_X86}/bin:${BASE_PATH}"
 
-  $SCONS platform=linuxbsd $OPTIONS tools=yes target=release_debug bits=32
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS tools=yes target=release_debug
   mkdir -p /root/out/x86_32/tools
   cp -rvp bin/* /root/out/x86_32/tools
   rm -rf bin
 
-  $SCONS platform=linuxbsd $OPTIONS tools=no target=release_debug bits=32
-  $SCONS platform=linuxbsd $OPTIONS tools=no target=release bits=32
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS tools=no target=release_debug
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS tools=no target=release
   mkdir -p /root/out/x86_32/templates
   cp -rvp bin/* /root/out/x86_32/templates
   rm -rf bin
@@ -63,13 +63,13 @@ if [ "${MONO}" == "1" ]; then
   export PATH="${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH}"
   export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86_64}"
 
-  $SCONS platform=linuxbsd $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
   mkdir -p /root/out/x86_64/tools-mono
   cp -rvp bin/* /root/out/x86_64/tools-mono
   rm -rf bin
 
-  $SCONS platform=linuxbsd $OPTIONS_MONO_PREFIX tools=no target=release_debug
-  $SCONS platform=linuxbsd $OPTIONS_MONO_PREFIX tools=no target=release
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS_MONO_PREFIX tools=no target=release_debug
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS_MONO_PREFIX tools=no target=release
   mkdir -p /root/out/x86_64/templates-mono
   cp -rvp bin/* /root/out/x86_64/templates-mono
   rm -rf bin
@@ -77,13 +77,13 @@ if [ "${MONO}" == "1" ]; then
   export PATH="${GODOT_SDK_LINUX_X86}/bin:${BASE_PATH}"
   export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86}"
 
-  $SCONS platform=linuxbsd $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes bits=32
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
   mkdir -p /root/out/x86_32/tools-mono
   cp -rvp bin/* /root/out/x86_32/tools-mono
   rm -rf bin
 
-  $SCONS platform=linuxbsd $OPTIONS_MONO_PREFIX tools=no target=release_debug bits=32
-  $SCONS platform=linuxbsd $OPTIONS_MONO_PREFIX tools=no target=release bits=32
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS_MONO_PREFIX tools=no target=release_debug
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS_MONO_PREFIX tools=no target=release
   mkdir -p /root/out/x86_32/templates-mono
   cp -rvp bin/* /root/out/x86_32/templates-mono
   rm -rf bin

--- a/build-release.sh
+++ b/build-release.sh
@@ -169,23 +169,23 @@ if [ "${build_classical}" == "1" ]; then
   ## Linux (Classical) ##
 
   # Editor
-  binname="${godot_basename}_linux.64"
-  cp out/linux/x86_64/tools/godot.linuxbsd.opt.tools.64 ${binname}
+  binname="${godot_basename}_linux.x86_64"
+  cp out/linux/x86_64/tools/godot.linuxbsd.opt.tools.x86_64 ${binname}
   strip ${binname}
   zip -q -9 "${reldir}/${binname}.zip" ${binname}
   rm ${binname}
 
-  binname="${godot_basename}_linux.32"
-  cp out/linux/x86_32/tools/godot.linuxbsd.opt.tools.32 ${binname}
+  binname="${godot_basename}_linux.x86_32"
+  cp out/linux/x86_32/tools/godot.linuxbsd.opt.tools.x86_32 ${binname}
   strip ${binname}
   zip -q -9 "${reldir}/${binname}.zip" ${binname}
   rm ${binname}
 
   # Templates
-  cp out/linux/x86_64/templates/godot.linuxbsd.opt.64 ${templatesdir}/linux_release.x86_64
-  cp out/linux/x86_64/templates/godot.linuxbsd.opt.debug.64 ${templatesdir}/linux_debug.x86_64
-  cp out/linux/x86_32/templates/godot.linuxbsd.opt.32 ${templatesdir}/linux_release.x86_32
-  cp out/linux/x86_32/templates/godot.linuxbsd.opt.debug.32 ${templatesdir}/linux_debug.x86_32
+  cp out/linux/x86_64/templates/godot.linuxbsd.opt.x86_64 ${templatesdir}/linux_release.x86_64
+  cp out/linux/x86_64/templates/godot.linuxbsd.opt.debug.x86_64 ${templatesdir}/linux_debug.x86_64
+  cp out/linux/x86_32/templates/godot.linuxbsd.opt.x86_32 ${templatesdir}/linux_release.x86_32
+  cp out/linux/x86_32/templates/godot.linuxbsd.opt.debug.x86_32 ${templatesdir}/linux_debug.x86_32
   strip ${templatesdir}/linux*
 
   ## Windows (Classical) ##
@@ -193,7 +193,7 @@ if [ "${build_classical}" == "1" ]; then
   # Editor
   binname="${godot_basename}_win64.exe"
   batname="${godot_basename}_win64_console.cmd"
-  cp out/windows/x86_64/tools/godot.windows.opt.tools.64.exe ${binname}
+  cp out/windows/x86_64/tools/godot.windows.opt.tools.x86_64.exe ${binname}
   strip ${binname}
   sign_windows ${binname}
   echo "@echo off" > ${batname}
@@ -204,7 +204,7 @@ if [ "${build_classical}" == "1" ]; then
 
   binname="${godot_basename}_win32.exe"
   batname="${godot_basename}_win32_console.cmd"
-  cp out/windows/x86_32/tools/godot.windows.opt.tools.32.exe ${binname}
+  cp out/windows/x86_32/tools/godot.windows.opt.tools.x86_32.exe ${binname}
   strip ${binname}
   sign_windows ${binname}
   echo "@echo off" > ${batname}
@@ -214,10 +214,10 @@ if [ "${build_classical}" == "1" ]; then
   rm ${binname} ${batname}
 
   # Templates
-  cp out/windows/x86_64/templates/godot.windows.opt.64.exe ${templatesdir}/windows_release_x86_64.exe
-  cp out/windows/x86_64/templates/godot.windows.opt.debug.64.exe ${templatesdir}/windows_debug_x86_64.exe
-  cp out/windows/x86_32/templates/godot.windows.opt.32.exe ${templatesdir}/windows_release_x86_32.exe
-  cp out/windows/x86_32/templates/godot.windows.opt.debug.32.exe ${templatesdir}/windows_debug_x86_32.exe
+  cp out/windows/x86_64/templates/godot.windows.opt.x86_64.exe ${templatesdir}/windows_release_x86_64.exe
+  cp out/windows/x86_64/templates/godot.windows.opt.debug.x86_64.exe ${templatesdir}/windows_debug_x86_64.exe
+  cp out/windows/x86_32/templates/godot.windows.opt.x86_32.exe ${templatesdir}/windows_release_x86_32.exe
+  cp out/windows/x86_32/templates/godot.windows.opt.debug.x86_32.exe ${templatesdir}/windows_debug_x86_32.exe
   strip ${templatesdir}/windows*.exe
 
   ## macOS (Classical) ##
@@ -353,30 +353,30 @@ if [ "${build_mono}" == "1" ]; then
 
   # Editor
   binbasename="${godot_basename}_mono_linux"
-  mkdir -p ${binbasename}_64
-  cp out/linux/x86_64/tools-mono/godot.linuxbsd.opt.tools.64.mono ${binbasename}_64/${binbasename}.64
-  strip ${binbasename}_64/${binbasename}.64
-  cp -rp out/linux/x86_64/tools-mono/GodotSharp ${binbasename}_64/
-  cp -rp out/aot-compilers ${binbasename}_64/GodotSharp/Tools/
-  zip -r -q -9 "${reldir_mono}/${binbasename}_64.zip" ${binbasename}_64
-  rm -rf ${binbasename}_64
+  mkdir -p ${binbasename}_x86_64
+  cp out/linux/x86_64/tools-mono/godot.linuxbsd.opt.tools.x86_64.mono ${binbasename}_x86_64/${binbasename}.x86_64
+  strip ${binbasename}_x86_64/${binbasename}.x86_64
+  cp -rp out/linux/x86_64/tools-mono/GodotSharp ${binbasename}_x86_64/
+  cp -rp out/aot-compilers ${binbasename}_x86_64/GodotSharp/Tools/
+  zip -r -q -9 "${reldir_mono}/${binbasename}_x86_64.zip" ${binbasename}_x86_64
+  rm -rf ${binbasename}_x86_64
 
   binbasename="${godot_basename}_mono_linux"
-  mkdir -p ${binbasename}_32
-  cp out/linux/x86_32/tools-mono/godot.linuxbsd.opt.tools.32.mono ${binbasename}_32/${binbasename}.32
-  strip ${binbasename}_32/${binbasename}.32
-  cp -rp out/linux/x86_32/tools-mono/GodotSharp/ ${binbasename}_32/
-  cp -rp out/aot-compilers ${binbasename}_32/GodotSharp/Tools/
-  zip -r -q -9 "${reldir_mono}/${binbasename}_32.zip" ${binbasename}_32
-  rm -rf ${binbasename}_32
+  mkdir -p ${binbasename}_x86_32
+  cp out/linux/x86_32/tools-mono/godot.linuxbsd.opt.tools.x86_32.mono ${binbasename}_x86_32/${binbasename}.x86_32
+  strip ${binbasename}_x86_32/${binbasename}.x86_32
+  cp -rp out/linux/x86_32/tools-mono/GodotSharp/ ${binbasename}_x86_32/
+  cp -rp out/aot-compilers ${binbasename}_x86_32/GodotSharp/Tools/
+  zip -r -q -9 "${reldir_mono}/${binbasename}_x86_32.zip" ${binbasename}_x86_32
+  rm -rf ${binbasename}_x86_32
 
   # Templates
-  cp -rp out/linux/x86_64/templates-mono/data.mono.linuxbsd.64.* ${templatesdir_mono}/
-  cp out/linux/x86_64/templates-mono/godot.linuxbsd.opt.debug.64.mono ${templatesdir_mono}/linux_debug.x86_64
-  cp out/linux/x86_64/templates-mono/godot.linuxbsd.opt.64.mono ${templatesdir_mono}/linux_release.x86_64
-  cp -rp out/linux/x86_32/templates-mono/data.mono.linuxbsd.32.* ${templatesdir_mono}/
-  cp out/linux/x86_32/templates-mono/godot.linuxbsd.opt.debug.32.mono ${templatesdir_mono}/linux_debug.x86_32
-  cp out/linux/x86_32/templates-mono/godot.linuxbsd.opt.32.mono ${templatesdir_mono}/linux_release.x86_32
+  cp -rp out/linux/x86_64/templates-mono/data.mono.linuxbsd.x86_64.* ${templatesdir_mono}/
+  cp out/linux/x86_64/templates-mono/godot.linuxbsd.opt.debug.x86_64.mono ${templatesdir_mono}/linux_debug.x86_64
+  cp out/linux/x86_64/templates-mono/godot.linuxbsd.opt.x86_64.mono ${templatesdir_mono}/linux_release.x86_64
+  cp -rp out/linux/x86_32/templates-mono/data.mono.linuxbsd.x86_32.* ${templatesdir_mono}/
+  cp out/linux/x86_32/templates-mono/godot.linuxbsd.opt.debug.x86_32.mono ${templatesdir_mono}/linux_debug.x86_32
+  cp out/linux/x86_32/templates-mono/godot.linuxbsd.opt.x86_32.mono ${templatesdir_mono}/linux_release.x86_32
   strip ${templatesdir_mono}/linux*
 
   mkdir -p ${templatesdir_mono}/bcl
@@ -388,7 +388,7 @@ if [ "${build_mono}" == "1" ]; then
   binname="${godot_basename}_mono_win64"
   batname="${godot_basename}_mono_win64_console.cmd"
   mkdir -p ${binname}
-  cp out/windows/x86_64/tools-mono/godot.windows.opt.tools.64.mono.exe ${binname}/${binname}.exe
+  cp out/windows/x86_64/tools-mono/godot.windows.opt.tools.x86_64.mono.exe ${binname}/${binname}.exe
   strip ${binname}/${binname}.exe
   sign_windows ${binname}/${binname}.exe
   cp -rp out/windows/x86_64/tools-mono/GodotSharp ${binname}/
@@ -403,7 +403,7 @@ if [ "${build_mono}" == "1" ]; then
   binname="${godot_basename}_mono_win32"
   batname="${godot_basename}_mono_win32_console.cmd"
   mkdir -p ${binname}
-  cp out/windows/x86_32/tools-mono/godot.windows.opt.tools.32.mono.exe ${binname}/${binname}.exe
+  cp out/windows/x86_32/tools-mono/godot.windows.opt.tools.x86_32.mono.exe ${binname}/${binname}.exe
   strip ${binname}/${binname}.exe
   sign_windows ${binname}/${binname}.exe
   cp -rp out/windows/x86_32/tools-mono/GodotSharp ${binname}/
@@ -416,12 +416,12 @@ if [ "${build_mono}" == "1" ]; then
   rm -rf ${binname}
 
   # Templates
-  cp -rp out/windows/x86_64/templates-mono/data.mono.windows.64.* ${templatesdir_mono}/
-  cp out/windows/x86_64/templates-mono/godot.windows.opt.debug.64.mono.exe ${templatesdir_mono}/windows_debug_x86_64.exe
-  cp out/windows/x86_64/templates-mono/godot.windows.opt.64.mono.exe ${templatesdir_mono}/windows_release_x86_64.exe
-  cp -rp out/windows/x86_32/templates-mono/data.mono.windows.32.* ${templatesdir_mono}/
-  cp out/windows/x86_32/templates-mono/godot.windows.opt.debug.32.mono.exe ${templatesdir_mono}/windows_debug_x86_32.exe
-  cp out/windows/x86_32/templates-mono/godot.windows.opt.32.mono.exe ${templatesdir_mono}/windows_release_x86_32.exe
+  cp -rp out/windows/x86_64/templates-mono/data.mono.windows.x86_64.* ${templatesdir_mono}/
+  cp out/windows/x86_64/templates-mono/godot.windows.opt.debug.x86_64.mono.exe ${templatesdir_mono}/windows_debug_x86_64.exe
+  cp out/windows/x86_64/templates-mono/godot.windows.opt.x86_64.mono.exe ${templatesdir_mono}/windows_release_x86_64.exe
+  cp -rp out/windows/x86_32/templates-mono/data.mono.windows.x86_32.* ${templatesdir_mono}/
+  cp out/windows/x86_32/templates-mono/godot.windows.opt.debug.x86_32.mono.exe ${templatesdir_mono}/windows_debug_x86_32.exe
+  cp out/windows/x86_32/templates-mono/godot.windows.opt.x86_32.mono.exe ${templatesdir_mono}/windows_release_x86_32.exe
   strip ${templatesdir_mono}/windows*.exe
 
   mkdir -p ${templatesdir_mono}/bcl

--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -21,24 +21,24 @@ tar xf /root/godot.tar.gz --strip-components=1
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for Windows..."
 
-  $SCONS platform=windows bits=64 $OPTIONS tools=yes target=release_debug
+  $SCONS platform=windows arch=x86_64 $OPTIONS tools=yes target=release_debug
   mkdir -p /root/out/x86_64/tools
   cp -rvp bin/* /root/out/x86_64/tools
   rm -rf bin
 
-  $SCONS platform=windows bits=64 $OPTIONS tools=no target=release_debug
-  $SCONS platform=windows bits=64 $OPTIONS tools=no target=release
+  $SCONS platform=windows arch=x86_64 $OPTIONS tools=no target=release_debug
+  $SCONS platform=windows arch=x86_64 $OPTIONS tools=no target=release
   mkdir -p /root/out/x86_64/templates
   cp -rvp bin/* /root/out/x86_64/templates
   rm -rf bin
 
-  $SCONS platform=windows bits=32 $OPTIONS tools=yes target=release_debug
+  $SCONS platform=windows arch=x86_32 $OPTIONS tools=yes target=release_debug
   mkdir -p /root/out/x86_32/tools
   cp -rvp bin/* /root/out/x86_32/tools
   rm -rf bin
 
-  $SCONS platform=windows bits=32 $OPTIONS tools=no target=release_debug
-  $SCONS platform=windows bits=32 $OPTIONS tools=no target=release
+  $SCONS platform=windows arch=x86_32 $OPTIONS tools=no target=release_debug
+  $SCONS platform=windows arch=x86_32 $OPTIONS tools=no target=release
   mkdir -p /root/out/x86_32/templates
   cp -rvp bin/* /root/out/x86_32/templates
   rm -rf bin
@@ -55,26 +55,26 @@ if [ "${MONO}" == "1" ]; then
 
   export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86_64}"
 
-  $SCONS platform=windows bits=64 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=windows arch=x86_64 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
   mkdir -p /root/out/x86_64/tools-mono
   cp -rvp bin/* /root/out/x86_64/tools-mono
   rm -rf bin
 
-  $SCONS platform=windows bits=64 $OPTIONS_MONO_PREFIX tools=no target=release_debug
-  $SCONS platform=windows bits=64 $OPTIONS_MONO_PREFIX tools=no target=release
+  $SCONS platform=windows arch=x86_64 $OPTIONS_MONO_PREFIX tools=no target=release_debug
+  $SCONS platform=windows arch=x86_64 $OPTIONS_MONO_PREFIX tools=no target=release
   mkdir -p /root/out/x86_64/templates-mono
   cp -rvp bin/* /root/out/x86_64/templates-mono
   rm -rf bin
 
   export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86}"
 
-  $SCONS platform=windows bits=32 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=windows arch=x86_32 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
   mkdir -p /root/out/x86_32/tools-mono
   cp -rvp bin/* /root/out/x86_32/tools-mono
   rm -rf bin
 
-  $SCONS platform=windows bits=32 $OPTIONS_MONO_PREFIX tools=no target=release_debug
-  $SCONS platform=windows bits=32 $OPTIONS_MONO_PREFIX tools=no target=release
+  $SCONS platform=windows arch=x86_32 $OPTIONS_MONO_PREFIX tools=no target=release_debug
+  $SCONS platform=windows arch=x86_32 $OPTIONS_MONO_PREFIX tools=no target=release
   mkdir -p /root/out/x86_32/templates-mono
   cp -rvp bin/* /root/out/x86_32/templates-mono
   rm -rf bin


### PR DESCRIPTION
This PR explicitly sets the `arch=` flag for Windows and Linux build commands. In the current master, explicitly setting `env["arch"]` to x86 basically only changes the file name suffix. This PR should make the build scripts forwards compatible with https://github.com/godotengine/godot/pull/55778 yet still work with the current master of Godot.

Note: I haven't tested this PR. Most of it is replacing `.64` with `.x86_64` etc so it probably works.