### PR TITLE
JavaScript: Re-enable build for 4.0 now that WebGL 2 works

### DIFF
--- a/build-javascript/build.sh
+++ b/build-javascript/build.sh
@@ -5,8 +5,8 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="production=yes"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no"
+export OPTIONS="production=yes use_thinlto=yes"
+export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no use_thinlto=no"
 export TERM=xterm
 
 rm -rf godot
@@ -24,9 +24,6 @@ if [ "${CLASSICAL}" == "1" ]; then
   $SCONS platform=javascript ${OPTIONS} target=release_debug tools=no
   $SCONS platform=javascript ${OPTIONS} target=release tools=no
 
-  $SCONS platform=javascript ${OPTIONS} target=release_debug tools=no threads_enabled=yes
-  $SCONS platform=javascript ${OPTIONS} target=release tools=no threads_enabled=yes
-
   $SCONS platform=javascript ${OPTIONS} target=release_debug tools=no gdnative_enabled=yes
   $SCONS platform=javascript ${OPTIONS} target=release tools=no gdnative_enabled=yes
 
@@ -34,7 +31,7 @@ if [ "${CLASSICAL}" == "1" ]; then
   cp -rvp bin/*.zip /root/out/templates
   rm -f bin/*.zip
 
-  $SCONS platform=javascript ${OPTIONS} target=release_debug tools=yes threads_enabled=yes use_closure_compiler=yes
+  $SCONS platform=javascript ${OPTIONS} target=release_debug tools=yes use_closure_compiler=yes
 
   mkdir -p /root/out/tools
   cp -rvp bin/*.zip /root/out/tools

--- a/build-release.sh
+++ b/build-release.sh
@@ -245,23 +245,20 @@ if [ "${build_classical}" == "1" ]; then
   rm -rf macos_template.app
   sign_macos_template ${templatesdir} 0
 
-#  ## Javascript (Classical) ##
-#
-#  # Editor
-#  unzip out/javascript/tools/godot.javascript.opt.tools.threads.zip -d ${webdir}/
-#  brotli --keep --force --quality=11 ${webdir}/*
-#  binname="${godot_basename}_web_editor.zip"
-#  cp out/javascript/tools/godot.javascript.opt.tools.threads.zip ${reldir}/${binname}
-#
-#  # Templates
-#  cp out/javascript/templates/godot.javascript.opt.zip ${templatesdir}/webassembly_release.zip
-#  cp out/javascript/templates/godot.javascript.opt.debug.zip ${templatesdir}/webassembly_debug.zip
-#
-#  cp out/javascript/templates/godot.javascript.opt.threads.zip ${templatesdir}/webassembly_threads_release.zip
-#  cp out/javascript/templates/godot.javascript.opt.debug.threads.zip ${templatesdir}/webassembly_threads_debug.zip
-#
-#  cp out/javascript/templates/godot.javascript.opt.gdnative.zip ${templatesdir}/webassembly_gdnative_release.zip
-#  cp out/javascript/templates/godot.javascript.opt.debug.gdnative.zip ${templatesdir}/webassembly_gdnative_debug.zip
+  ## Javascript (Classical) ##
+
+  # Editor
+  unzip out/javascript/tools/godot.javascript.opt.tools.threads.zip -d ${webdir}/
+  brotli --keep --force --quality=11 ${webdir}/*
+  binname="${godot_basename}_web_editor.zip"
+  cp out/javascript/tools/godot.javascript.opt.tools.threads.zip ${reldir}/${binname}
+
+  # Templates
+  cp out/javascript/templates/godot.javascript.opt.threads.zip ${templatesdir}/webassembly_threads_release.zip
+  cp out/javascript/templates/godot.javascript.opt.debug.threads.zip ${templatesdir}/webassembly_threads_debug.zip
+
+  cp out/javascript/templates/godot.javascript.opt.gdnative.threads.zip ${templatesdir}/webassembly_gdnative_threads_release.zip
+  cp out/javascript/templates/godot.javascript.opt.debug.gdnative.threads.zip ${templatesdir}/webassembly_gdnative_threads_debug.zip
 
   ## Android (Classical) ##
 

--- a/build.sh
+++ b/build.sh
@@ -198,8 +198,8 @@ ${podman_run} -v ${basedir}/build-windows:/root/build -v ${basedir}/out/windows:
 mkdir -p ${basedir}/out/linux
 ${podman_run} -v ${basedir}/build-linux:/root/build -v ${basedir}/out/linux:/root/out localhost/godot-linux:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/linux
 
-#mkdir -p ${basedir}/out/javascript
-#${podman_run} -v ${basedir}/build-javascript:/root/build -v ${basedir}/out/javascript:/root/out localhost/godot-javascript:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/javascript
+mkdir -p ${basedir}/out/javascript
+${podman_run} -v ${basedir}/build-javascript:/root/build -v ${basedir}/out/javascript:/root/out localhost/godot-javascript:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/javascript
 
 mkdir -p ${basedir}/out/macos
 ${podman_run} -v ${basedir}/build-macos:/root/build -v ${basedir}/out/macos:/root/out -v ${basedir}/deps/vulkansdk-macos:/root/vulkansdk localhost/godot-osx:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/macos


### PR DESCRIPTION
I made a test build with these changes yesterday: https://downloads.tuxfamily.org/godotengine/testing/4.0.alpha15-ish.web/

I couldn't get the web editor build to render anything in Firefox or Chromium on Linux, not sure why.
It might be my CORS server deployment methods which isn't working as expected. Or maybe we regressed on WebGL 2.0 support again.