### PR TITLE
.NET 6: Initial port of build scripts for 4.0

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -6,7 +6,7 @@ set -e
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=no"
+export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
 rm -rf godot
@@ -62,17 +62,17 @@ if [ "${MONO}" == "1" ]; then
   cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
 
-  $SCONS platform=android android_arch=armv7 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-armv7-release tools=no target=release_debug
-  $SCONS platform=android android_arch=armv7 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-armv7-release tools=no target=release
+  $SCONS platform=android android_arch=armv7 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=android android_arch=armv7 $OPTIONS $OPTIONS_MONO tools=no target=release
 
-  $SCONS platform=android android_arch=arm64v8 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-arm64v8-release tools=no target=release_debug
-  $SCONS platform=android android_arch=arm64v8 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-arm64v8-release tools=no target=release
+  $SCONS platform=android android_arch=arm64v8 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=android android_arch=arm64v8 $OPTIONS $OPTIONS_MONO tools=no target=release
 
-  $SCONS platform=android android_arch=x86 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86-release tools=no target=release_debug
-  $SCONS platform=android android_arch=x86 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86-release tools=no target=release
+  $SCONS platform=android android_arch=x86 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=android android_arch=x86 $OPTIONS $OPTIONS_MONO tools=no target=release
 
-  $SCONS platform=android android_arch=x86_64 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86_64-release tools=no target=release_debug
-  $SCONS platform=android android_arch=x86_64 $OPTIONS $OPTIONS_MONO mono_prefix=/root/mono-installs/android-x86_64-release tools=no target=release
+  $SCONS platform=android android_arch=x86_64 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=android android_arch=x86_64 $OPTIONS $OPTIONS_MONO tools=no target=release
 
   pushd platform/android/java
   ./gradlew generateGodotTemplates
@@ -83,9 +83,6 @@ if [ "${MONO}" == "1" ]; then
   cp bin/android_debug.apk /root/out/templates-mono/
   cp bin/android_release.apk /root/out/templates-mono/
   cp bin/godot-lib.release.aar /root/out/templates-mono/
-
-  mkdir -p /root/out/templates-mono/bcl
-  cp -r /root/mono-installs/android-bcl/* /root/out/templates-mono/bcl/
 fi
 
 echo "Android build successful"

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -8,7 +8,7 @@ export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 # Keep LTO disabled for iOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
 export OPTIONS="production=yes use_lto=no"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
+export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
 export IOS_SDK="15.4"
@@ -60,26 +60,25 @@ if [ "${MONO}" == "1" ]; then
 
   cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
-  cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
   # arm64 device
-  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=no mono_prefix=/root/mono-installs/ios-arm64-release tools=no target=release_debug \
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=no tools=no target=release_debug \
     IOS_SDK_PATH="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
-  $SCONS platform=iios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=no mono_prefix=/root/mono-installs/ios-arm64-release tools=no target=release \
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=no tools=no target=release \
     IOS_SDK_PATH="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
 
   # arm64 simulator
   # Disabled for now as it doesn't work with cctools-port and current LLVM.
   # See https://github.com/godotengine/build-containers/pull/85.
-  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-arm64-sim-release tools=no target=release_debug \
+  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes tools=no target=release_debug \
   #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
-  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-arm64-sim-release tools=no target=release \
+  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes tools=no target=release \
   #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
 
   # x86_64 simulator
-  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release_debug \
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes tools=no target=release_debug \
     IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
-  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release \
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes tools=no target=release \
     IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
 
   mkdir -p /root/out/templates-mono
@@ -90,27 +89,6 @@ if [ "${MONO}" == "1" ]; then
   #$IOS_LIPO -create bin/libgodot.ios.opt.debug.arm64.simulator.a bin/libgodot.ios.opt.debug.x86_64.simulator.a -output /root/out/templates-mono/libgodot.ios.debug.simulator.a
   cp bin/libgodot.ios.opt.x86_64.simulator.a /root/out/templates-mono/libgodot.ios.simulator.a
   cp bin/libgodot.ios.opt.debug.x86_64.simulator.a /root/out/templates-mono/libgodot.ios.debug.simulator.a
-
-  cp -r misc/dist/ios-mono-libs /root/out/templates-mono/ios-mono-libs
-
-  cp bin/libmonosgen-2.0.ios.arm64.a /root/out/templates-mono/ios-mono-libs/libmonosgen-2.0.xcframework/ios-arm64/libmonosgen.a
-  cp bin/libmono-native.ios.arm64.a /root/out/templates-mono/ios-mono-libs/libmono-native.xcframework/ios-arm64/libmono-native.a
-  cp bin/libmono-profiler-log.ios.arm64.a /root/out/templates-mono/ios-mono-libs/libmono-profiler-log.xcframework/ios-arm64/libmono-profiler-log.a
-
-  #$IOS_LIPO -create bin/libmonosgen-2.0.ios.arm64.simulator.a bin/libmonosgen-2.0.ios.x86_64.simulator.a -output /root/out/templates-mono/ios-mono-libs/libmonosgen-2.0.xcframework/ios-arm64_x86_64-simulator/libmonosgen.a
-  #$IOS_LIPO -create bin/libmono-native.ios.arm64.simulator.a bin/libmono-native.ios.x86_64.simulator.a -output /root/out/templates-mono/ios-mono-libs/libmono-native.xcframework/ios-arm64_x86_64-simulator/libmono-native.a
-  #$IOS_LIPO -create bin/libmono-profiler-log.ios.arm64.simulator.a bin/libmono-profiler-log.ios.x86_64.simulator.a -output /root/out/templates-mono/ios-mono-libs/libmono-profiler-log.xcframework/ios-arm64_x86_64-simulator/libmono-profiler-log.a
-  cp bin/libmonosgen-2.0.ios.x86_64.simulator.a /root/out/templates-mono/ios-mono-libs/libmonosgen-2.0.xcframework/ios-arm64_x86_64-simulator/libmonosgen.a
-  cp bin/libmono-native.ios.x86_64.simulator.a /root/out/templates-mono/ios-mono-libs/libmono-native.xcframework/ios-arm64_x86_64-simulator/libmono-native.a
-  cp bin/libmono-profiler-log.ios.x86_64.simulator.a /root/out/templates-mono/ios-mono-libs/libmono-profiler-log.xcframework/ios-arm64_x86_64-simulator/libmono-profiler-log.a
-
-  # The Mono libraries for the interpreter are not available for simulator builds
-  cp bin/libmono-ee-interp.ios.arm64.a /root/out/templates-mono/ios-mono-libs/libmono-ee-interp.xcframework/ios-arm64/libmono-ee-interp.a
-  cp bin/libmono-icall-table.ios.arm64.a /root/out/templates-mono/ios-mono-libs/libmono-icall-table.xcframework/ios-arm64/libmono-icall-table.a
-  cp bin/libmono-ilgen.ios.arm64.a /root/out/templates-mono/ios-mono-libs/libmono-ilgen.xcframework/ios-arm64/libmono-ilgen.a
-
-  mkdir -p /root/out/templates-mono/bcl
-  cp -r /root/mono-installs/ios-bcl/* /root/out/templates-mono/bcl
 fi
 
 echo "iOS build successful"

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -6,9 +6,7 @@ set -e
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
-export MONO_PREFIX_X86_64="/root/mono-installs/desktop-linux-x86_64-release"
-export MONO_PREFIX_X86="/root/mono-installs/desktop-linux-x86-release"
+export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
 rm -rf godot
@@ -56,34 +54,33 @@ fi
 if [ "${MONO}" == "1" ]; then
   echo "Starting Mono build for Linux..."
 
-  cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
   export PATH="${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH}"
-  export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86_64}"
 
-  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS $OPTIONS_MONO tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS $OPTIONS_MONO tools=yes target=release_debug
+  ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
   mkdir -p /root/out/x86_64/tools-mono
   cp -rvp bin/* /root/out/x86_64/tools-mono
   rm -rf bin
 
-  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS_MONO_PREFIX tools=no target=release_debug
-  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS_MONO_PREFIX tools=no target=release
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=linuxbsd arch=x86_64 $OPTIONS $OPTIONS_MONO tools=no target=release
   mkdir -p /root/out/x86_64/templates-mono
   cp -rvp bin/* /root/out/x86_64/templates-mono
   rm -rf bin
 
   export PATH="${GODOT_SDK_LINUX_X86}/bin:${BASE_PATH}"
-  export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86}"
 
-  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS $OPTIONS_MONO tools=yes target=release_debug
+  ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
   mkdir -p /root/out/x86_32/tools-mono
   cp -rvp bin/* /root/out/x86_32/tools-mono
   rm -rf bin
 
-  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS_MONO_PREFIX tools=no target=release_debug
-  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS_MONO_PREFIX tools=no target=release
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=linuxbsd arch=x86_32 $OPTIONS $OPTIONS_MONO tools=no target=release
   mkdir -p /root/out/x86_32/templates-mono
   cp -rvp bin/* /root/out/x86_32/templates-mono
   rm -rf bin

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -19,13 +19,13 @@ tar xf ../godot.tar.gz --strip-components=1
 if [ "${MONO}" == "1" ]; then
   echo "Building and generating Mono glue..."
 
-  mono --version
+  dotnet --info
   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
 
-  ${SCONS} platform=linuxbsd bits=64 ${OPTIONS} target=release_debug tools=yes module_mono_enabled=yes mono_glue=no
+  ${SCONS} platform=linuxbsd ${OPTIONS} target=release_debug tools=yes module_mono_enabled=yes
 
   rm -rf /root/mono-glue/*
-  bin/godot.linuxbsd.opt.tools.64.mono --display-driver headless --audio-driver Dummy --generate-mono-glue /root/mono-glue || /bin/true
+  bin/godot.linuxbsd.opt.tools.x86_64.mono --headless --generate-mono-glue /root/mono-glue
 fi
 
 echo "Mono glue generated successfully"

--- a/build-web/build.sh
+++ b/build-web/build.sh
@@ -6,8 +6,10 @@ set -e
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes use_thinlto=yes"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes mono_prefix=/root/mono-installs/wasm-runtime-release use_lto=no use_thinlto=no"
+export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
+
+source /root/emsdk/emsdk_env.sh
 
 rm -rf godot
 mkdir godot
@@ -18,8 +20,6 @@ tar xf /root/godot.tar.gz --strip-components=1
 
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for Web..."
-
-  source /root/emsdk_${EMSCRIPTEN_CLASSICAL}/emsdk_env.sh
 
   $SCONS platform=web ${OPTIONS} target=release_debug tools=no
   $SCONS platform=web ${OPTIONS} target=release tools=no
@@ -36,7 +36,6 @@ if [ "${CLASSICAL}" == "1" ]; then
   mkdir -p /root/out/tools
   cp -rvp bin/*.zip /root/out/tools
   rm -f bin/*.zip
-
 fi
 
 # Mono
@@ -44,11 +43,8 @@ fi
 if [ "${MONO}" == "1" ]; then
   echo "Starting Mono build for Web..."
 
-  source /root/emsdk_${EMSCRIPTEN_MONO}/emsdk_env.sh
-
   cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
-  cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
   $SCONS platform=web ${OPTIONS} ${OPTIONS_MONO} target=release_debug tools=no
   $SCONS platform=web ${OPTIONS} ${OPTIONS_MONO} target=release tools=no
@@ -56,9 +52,6 @@ if [ "${MONO}" == "1" ]; then
   mkdir -p /root/out/templates-mono
   cp -rvp bin/*.zip /root/out/templates-mono
   rm -f bin/*.zip
-
-  mkdir -p /root/out/templates-mono/bcl
-  cp -r /root/mono-installs/wasm-bcl/wasm /root/out/templates-mono/bcl/
 fi
 
 echo "Web build successful"

--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -6,9 +6,7 @@ set -e
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
-export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
-export MONO_PREFIX_X86_64="/root/mono-installs/desktop-windows-x86_64-release"
-export MONO_PREFIX_X86="/root/mono-installs/desktop-windows-x86-release"
+export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
 rm -rf godot
@@ -49,32 +47,29 @@ fi
 if [ "${MONO}" == "1" ]; then
   echo "Starting Mono build for Windows..."
 
-  cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
-  export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86_64}"
-
-  $SCONS platform=windows arch=x86_64 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=windows arch=x86_64 $OPTIONS $OPTIONS_MONO tools=yes target=release_debug
+  ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows
   mkdir -p /root/out/x86_64/tools-mono
   cp -rvp bin/* /root/out/x86_64/tools-mono
   rm -rf bin
 
-  $SCONS platform=windows arch=x86_64 $OPTIONS_MONO_PREFIX tools=no target=release_debug
-  $SCONS platform=windows arch=x86_64 $OPTIONS_MONO_PREFIX tools=no target=release
+  $SCONS platform=windows arch=x86_64 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=windows arch=x86_64 $OPTIONS $OPTIONS_MONO tools=no target=release
   mkdir -p /root/out/x86_64/templates-mono
   cp -rvp bin/* /root/out/x86_64/templates-mono
   rm -rf bin
 
-  export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86}"
-
-  $SCONS platform=windows arch=x86_32 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
+  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO tools=yes target=release_debug
+  ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows
   mkdir -p /root/out/x86_32/tools-mono
   cp -rvp bin/* /root/out/x86_32/tools-mono
   rm -rf bin
 
-  $SCONS platform=windows arch=x86_32 $OPTIONS_MONO_PREFIX tools=no target=release_debug
-  $SCONS platform=windows arch=x86_32 $OPTIONS_MONO_PREFIX tools=no target=release
+  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO tools=no target=release_debug
+  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO tools=no target=release
   mkdir -p /root/out/x86_32/templates-mono
   cp -rvp bin/* /root/out/x86_32/templates-mono
   rm -rf bin

--- a/build.sh
+++ b/build.sh
@@ -122,7 +122,7 @@ fi
 
 if [ $skip_download == 0 ]; then
   echo "Fetching images"
-  for image in mono-glue windows linux web; do
+  for image in windows linux web; do
     if [ ${force_download} == 1 ] || ! ${podman} image exists godot/$image; then
       if ! ${podman} pull ${registry}/godot/${image}; then
         echo "ERROR: image $image does not exist and can't be downloaded"
@@ -184,13 +184,8 @@ mkdir -p ${basedir}/out/logs
 export podman_run="${podman} run -it --rm --env BUILD_NAME --env GODOT_VERSION_STATUS --env NUM_CORES --env CLASSICAL=${build_classical} --env MONO=${build_mono} -v ${basedir}/godot-${godot_version}.tar.gz:/root/godot.tar.gz -v ${basedir}/mono-glue:/root/mono-glue -w /root/"
 export img_version=4.x-f36
 
-# Get AOT compilers from their containers.
-mkdir -p ${basedir}/out/aot-compilers
-${podman} run -it --rm -w /root -v ${basedir}/out/aot-compilers:/root/out localhost/godot-ios:${img_version} bash -c "cp -r /root/aot-compilers/* /root/out"
-chmod +x ${basedir}/out/aot-compilers/*/*
-
 mkdir -p ${basedir}/mono-glue
-${podman_run} -v ${basedir}/build-mono-glue:/root/build localhost/godot-mono-glue:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/mono-glue
+${podman_run} -v ${basedir}/build-mono-glue:/root/build localhost/godot-linux:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/mono-glue
 
 mkdir -p ${basedir}/out/windows
 ${podman_run} -v ${basedir}/build-windows:/root/build -v ${basedir}/out/windows:/root/out localhost/godot-windows:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/windows


### PR DESCRIPTION
~Draft for now, only ported Linux and Windows for testing,~ and the Linux builds are failing to link `libnethost.a` (and I suspect the Windows builds would fail like https://github.com/godotengine/godot/issues/64950).

*Edit:* Not working yet but cleans up a lot of the Mono stuff we won't need anymore. But at least all platform code is updated so I can do further refactoring without having the Mono things in the way.

Uses containers from https://github.com/godotengine/build-containers/pull/113.