### PR TITLE
Web: Handle new template names and `dlink_enabled=yes`

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -248,17 +248,17 @@ if [ "${build_classical}" == "1" ]; then
   ## Web (Classical) ##
 
   # Editor
-  unzip out/web/tools/godot.web.opt.tools.threads.zip -d ${webdir}/
+  unzip out/web/tools/godot.web.opt.tools.wasm32.zip -d ${webdir}/
   brotli --keep --force --quality=11 ${webdir}/*
   binname="${godot_basename}_web_editor.zip"
-  cp out/web/tools/godot.web.opt.tools.threads.zip ${reldir}/${binname}
+  cp out/web/tools/godot.web.opt.tools.wasm32.zip ${reldir}/${binname}
 
   # Templates
-  cp out/web/templates/godot.web.opt.threads.zip ${templatesdir}/webassembly_threads_release.zip
-  cp out/web/templates/godot.web.opt.debug.threads.zip ${templatesdir}/webassembly_threads_debug.zip
+  cp out/web/templates/godot.web.opt.wasm32.zip ${templatesdir}/web_release.zip
+  cp out/web/templates/godot.web.opt.debug.wasm32.zip ${templatesdir}/web_debug.zip
 
-  cp out/web/templates/godot.web.opt.gdnative.threads.zip ${templatesdir}/webassembly_gdnative_threads_release.zip
-  cp out/web/templates/godot.web.opt.debug.gdnative.threads.zip ${templatesdir}/webassembly_gdnative_threads_debug.zip
+  cp out/web/templates/godot.web.opt.wasm32.dlink.zip ${templatesdir}/web_dlink_release.zip
+  cp out/web/templates/godot.web.opt.debug.wasm32.dlink.zip ${templatesdir}/web_dlink_debug.zip
 
   ## Android (Classical) ##
 
@@ -451,14 +451,11 @@ if [ "${build_mono}" == "1" ]; then
   rm -rf macos_template.app
   sign_macos_template ${templatesdir_mono} 1
 
-#  ## Web (Mono) ##
-#
-#  # Templates
-#  cp out/web/templates-mono/godot.web.opt.debug.mono.zip ${templatesdir_mono}/webassembly_debug.zip
-#  cp out/web/templates-mono/godot.web.opt.mono.zip ${templatesdir_mono}/webassembly_release.zip
-#
-#  mkdir -p ${templatesdir_mono}/bcl
-#  cp -r out/web/templates-mono/bcl/wasm ${templatesdir_mono}/bcl/
+  ## Web (Mono) ##
+
+  # Templates
+  cp out/web/templates-mono/godot.web.opt.debug.wasm32.mono.zip ${templatesdir_mono}/web_debug.zip
+  cp out/web/templates-mono/godot.web.opt.wasm32.mono.zip ${templatesdir_mono}/web_release.zip
 
   ## Android (Mono) ##
 

--- a/build-web/build.sh
+++ b/build-web/build.sh
@@ -5,8 +5,8 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="production=yes use_thinlto=yes"
-export OPTIONS_MONO="module_mono_enabled=yes"
+export OPTIONS="production=yes"
+export OPTIONS_MONO="module_mono_enabled=yes use_lto=no"
 export TERM=xterm
 
 source /root/emsdk/emsdk_env.sh
@@ -24,8 +24,8 @@ if [ "${CLASSICAL}" == "1" ]; then
   $SCONS platform=web ${OPTIONS} target=release_debug tools=no
   $SCONS platform=web ${OPTIONS} target=release tools=no
 
-  $SCONS platform=web ${OPTIONS} target=release_debug tools=no gdnative_enabled=yes
-  $SCONS platform=web ${OPTIONS} target=release tools=no gdnative_enabled=yes
+  $SCONS platform=web ${OPTIONS} target=release_debug tools=no dlink_enabled=yes
+  $SCONS platform=web ${OPTIONS} target=release tools=no dlink_enabled=yes
 
   mkdir -p /root/out/templates
   cp -rvp bin/*.zip /root/out/templates

--- a/build.sh
+++ b/build.sh
@@ -180,6 +180,7 @@ fi
 export basedir="$(pwd)"
 mkdir -p ${basedir}/out
 mkdir -p ${basedir}/out/logs
+mkdir -p ${basedir}/mono-glue
 
 export podman_run="${podman} run -it --rm --env BUILD_NAME --env GODOT_VERSION_STATUS --env NUM_CORES --env CLASSICAL=${build_classical} --env MONO=${build_mono} -v ${basedir}/godot-${godot_version}.tar.gz:/root/godot.tar.gz -v ${basedir}/mono-glue:/root/mono-glue -w /root/"
 export img_version=4.x-f36


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/65094.

Also reverts LTO change from #62, we found that while it's much slower to link, full LTO still produces smaller binaries and that's quite important for the Web platform.