### PR TITLE
.NET 6: Further update build scripts for 4.0, works for desktop releases

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -56,10 +56,11 @@ fi
 
 # Mono
 
-if [ "${MONO}" == "1" ]; then
+# No Android support with .NET 6 yet.
+#if [ "${MONO}" == "1" ]; then
+if false; then
   echo "Starting Mono build for Android..."
 
-  cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
 
   $SCONS platform=android arch=arm32 $OPTIONS $OPTIONS_MONO tools=no target=release_debug

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -55,10 +55,11 @@ fi
 
 # Mono
 
-if [ "${MONO}" == "1" ]; then
+# No iOS support with .NET 6 yet.
+#if [ "${MONO}" == "1" ]; then
+if false; then
   echo "Starting Mono build for iOS..."
 
-  cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
 
   # arm64 device

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -8,11 +8,18 @@ export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="debug_symbols=no use_static_cpp=no"
 export TERM=xterm
 export DISPLAY=:0
+export PATH="${GODOT_SDK_LINUX_X86_64}/bin:${BASE_PATH}"
 
 rm -rf godot
 mkdir godot
 cd godot
 tar xf ../godot.tar.gz --strip-components=1
+
+# pkg-config wrongly points to lib instead of lib64 for arch-dependent header.
+sed -i ${GODOT_SDK_LINUX_X86_64}/x86_64-godot-linux-gnu/sysroot/usr/lib/pkgconfig/dbus-1.pc -e "s@/lib@/lib64@g"
+
+# Temporarily until we make --headless mode actually skip X11.
+dnf install -y libX11 libXcursor libXrandr libXinerama libXi mesa-libGL
 
 # Mono
 

--- a/build-web/build.sh
+++ b/build-web/build.sh
@@ -55,10 +55,11 @@ fi
 
 # Mono
 
-if [ "${MONO}" == "1" ]; then
+# No Web support with .NET 6 yet.
+#if [ "${MONO}" == "1" ]; then
+if false; then
   echo "Starting Mono build for Web..."
 
-  cp /root/mono-glue/*.cpp modules/mono/glue/
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
 
   $SCONS platform=web ${OPTIONS} ${OPTIONS_MONO} target=release_debug tools=no


### PR DESCRIPTION
Does not attempt to build Android, iOS and Web since it's not supported currently.

Follow-up to #64.

Tested successfully with the desktop editor 64-bit builds so far: https://downloads.tuxfamily.org/godotengine/testing/4.0-alpha16-mono-editor/mono/

I'll now do a full build of all desktop editor and template builds to fully validate this PR and be ready for 4.0 beta 1.