### PR TITLE
Xcode: Update macOS and iOS scripts for to Xcode 14.1 (macOS 13.0, iOS 16.1)

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -11,7 +11,7 @@ export OPTIONS="production=yes use_lto=no"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
-export IOS_SDK="15.4"
+export IOS_SDK="16.1"
 export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
 
 rm -rf godot

--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -5,9 +5,9 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="osxcross_sdk=darwin21.4 production=yes use_volk=no vulkan_sdk_path=/root/vulkansdk"
+export OPTIONS="osxcross_sdk=darwin22 production=yes use_volk=no vulkan_sdk_path=/root/vulkansdk"
 export OPTIONS_MONO="module_mono_enabled=yes"
-export STRIP="x86_64-apple-darwin21.4-strip -u -r"
+export STRIP="x86_64-apple-darwin22-strip -u -r"
 export TERM=xterm
 
 rm -rf godot


### PR DESCRIPTION
Depends on https://github.com/godotengine/build-containers/pull/116