### PR TITLE
Add logic to upload the Godot Android library to MavenCentral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# User-specific configuration and signing key
+# User-specific configuration and signing keys
 config.sh
+*.jks
 *.pfx
 *.pkcs12
 

--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -14,6 +14,16 @@ mkdir godot
 cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
+# Environment variables and keystore needed for signing store editor build,
+# as well as signing and publishing to MavenCentral.
+source /root/keystore/config.sh
+
+store_release="yes"
+if [ -z "${GODOT_ANDROID_SIGN_KEYSTORE}" ]; then
+  echo "No keystore provided to sign the Android release editor build, using debug build instead."
+  store_release="no"
+fi
+
 # Classical
 
 dnf -y install gettext
@@ -21,17 +31,29 @@ dnf -y install gettext
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for Android..."
 
-  $SCONS platform=android arch=arm32 $OPTIONS target=editor
-  $SCONS platform=android arch=arm64 $OPTIONS target=editor
-  $SCONS platform=android arch=x86_32 $OPTIONS target=editor
-  $SCONS platform=android arch=x86_64 $OPTIONS target=editor
+  $SCONS platform=android arch=arm32 $OPTIONS target=editor store_release=${store_release}
+  $SCONS platform=android arch=arm64 $OPTIONS target=editor store_release=${store_release}
+  $SCONS platform=android arch=x86_32 $OPTIONS target=editor store_release=${store_release}
+  $SCONS platform=android arch=x86_64 $OPTIONS target=editor store_release=${store_release}
 
   pushd platform/android/java
   ./gradlew generateGodotEditor
   popd
 
   mkdir -p /root/out/tools
-  cp bin/android_editor.apk /root/out/tools/
+  # Copy the generated Android editor binaries (apk & aab).
+  if [ "$store_release" == "yes" ]; then
+    cp bin/android_editor_builds/android_editor-release.apk /root/out/tools/android_editor.apk
+    cp bin/android_editor_builds/android_editor-release.aab /root/out/tools/android_editor.aab
+  else
+    cp bin/android_editor_builds/android_editor-debug.apk /root/out/tools/android_editor.apk
+    cp bin/android_editor_builds/android_editor-debug.aab /root/out/tools/android_editor.aab
+  fi
+
+  # Restart from a clean tarball, as we'll copy all the contents
+  # outside the container for the MavenCentral upload.
+  rm -rf /root/godot/*
+  tar xf /root/godot.tar.gz --strip-components=1
 
   $SCONS platform=android arch=arm32 $OPTIONS target=template_debug
   $SCONS platform=android arch=arm32 $OPTIONS target=template_release
@@ -47,6 +69,14 @@ if [ "${CLASSICAL}" == "1" ]; then
 
   pushd platform/android/java
   ./gradlew generateGodotTemplates
+
+  if [ "$store_release" == "yes" ]; then
+    # Copy source folder with compiled libs so we can optionally use it
+    # in a separate script to upload the templates to MavenCentral.
+    cp -r /root/godot /root/out/source/
+    # Backup ~/.gradle too so we can reuse all the downloaded stuff.
+    cp -r /root/.gradle /root/out/source/.gradle
+  fi
   popd
 
   mkdir -p /root/out/templates

--- a/build-android/upload-mavencentral.sh
+++ b/build-android/upload-mavencentral.sh
@@ -1,0 +1,18 @@
+#/bin/bash
+
+basedir="$(pwd)"
+
+if [ ! -d "${basedir}/deps/keystore" ]; then
+  echo "Couldn't find ${basedir}/deps/keystore. Make sure to run this from the root folder of the Git repository."
+fi
+
+source ${basedir}/deps/keystore/config.sh
+
+# Release the Godot Android library to MavenCentral
+${PODMAN} run -it --rm \
+  -v ${basedir}/out/android/source:/root/godot -v ${basedir}/deps/keystore:/root/keystore \
+  localhost/godot-android:${IMAGE_VERSION} bash -c \
+    "source /root/keystore/config.sh && \
+    cp -r /root/godot/.gradle /root && \
+    cd /root/godot/platform/android/java && \
+    ./gradlew publishTemplateReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository"

--- a/build-release.sh
+++ b/build-release.sh
@@ -319,6 +319,8 @@ if [ "${build_classical}" == "1" ]; then
   # Editor
   binname="${godot_basename}_android_editor.apk"
   cp out/android/tools/android_editor.apk ${reldir}/${binname}
+  binname="${godot_basename}_android_editor.aab"
+  cp out/android/tools/android_editor.aab ${reldir}/${binname}
 
   # Templates
   cp out/android/templates/*.apk ${templatesdir}/

--- a/config.sh.in
+++ b/config.sh.in
@@ -3,16 +3,28 @@
 # Configuration file for user-specific details.
 # This file is gitignore'd and will be sourced by build scripts.
 
+# Note: For passwords or GPG keys, make sure that special characters such
+# as $ won't be expanded, by using single quotes to enclose the string,
+# or escaping with \$.
+
+# These scripts are designed and tested against podman. They may also work
+# with docker, but it's not guaranteed. You can set this variable to the
+# relevant tool in your PATH or an absolute path to run it from.
+export PODMAN='podman'
+
 # Registry for build containers.
 # The default registry is the one used for official Godot builds.
 # Note that some of its images are private and only accessible to selected
 # contributors.
 # You can build your own registry with scripts at
 # https://github.com/godotengine/build-containers
-export REGISTRY="registry.prehensile-tales.com"
+export REGISTRY='registry.prehensile-tales.com'
+
+# Version string of the images to use in build.sh.
+export IMAGE_VERSION='4.x-f36'
 
 # Default build name used to distinguish between official and custom builds.
-export BUILD_NAME="custom_build"
+export BUILD_NAME='custom_build'
 
 # Default number of parallel cores for each build.
 export NUM_CORES=16
@@ -21,28 +33,50 @@ export NUM_CORES=16
 # If you do not fill all SIGN_* fields, signing will be skipped.
 
 # Path to pkcs12 archive.
-export SIGN_KEYSTORE=""
+export SIGN_KEYSTORE=''
 
 # Password for the private key.
-export SIGN_PASSWORD=""
+export SIGN_PASSWORD=''
 
 # Name and URL of the signed application.
 # Use your own when making a thirdparty build.
-export SIGN_NAME=""
-export SIGN_URL=""
+export SIGN_NAME=''
+export SIGN_URL=''
 
-# Hostname or IP address of an macOS host (Needed for signing)
-# eg "user@10.1.0.10"
-export OSX_HOST=""
+# Hostname or IP address of an OSX host (Needed for signing)
+# eg 'user@10.1.0.10'
+export OSX_HOST=''
 # ID of the Apple certificate used to sign
-export OSX_KEY_ID=""
+export OSX_KEY_ID=''
 # Bundle id for the signed app
-export OSX_BUNDLE_ID=""
+export OSX_BUNDLE_ID=''
 # Username/password for Apple's signing APIs (used for atltool)
-export APPLE_ID=""
-export APPLE_ID_PASSWORD=""
+export APPLE_ID=''
+export APPLE_ID_PASSWORD=''
 
 # NuGet source for publishing .NET packages
-export NUGET_SOURCE="nuget.org"
+export NUGET_SOURCE='nuget.org'
 # API key for publishing NuGet packages to nuget.org
-export NUGET_API_KEY=""
+export NUGET_API_KEY=''
+
+# MavenCentral (sonatype) credentials
+export OSSRH_GROUP_ID=''
+export OSSRH_USERNAME=''
+export OSSRH_PASSWORD=''
+# Sonatype assigned ID used to upload the generated artifacts
+export SONATYPE_STAGING_PROFILE_ID=''
+# Used to sign the artifacts after they're built
+# ID of the GPG key pair, the last eight characters of its fingerprint
+export SIGNING_KEY_ID=''
+# Passphrase of the key pair
+export SIGNING_PASSWORD=''
+# Base64 encoded private GPG key
+export SIGNING_KEY=''
+
+# Android signing configs
+# Path to the Android keystore file used to sign the release build
+export GODOT_ANDROID_SIGN_KEYSTORE=''
+# Key alias used for signing the release build
+export GODOT_ANDROID_KEYSTORE_ALIAS=''
+# Password for the key used for signing the release build
+export GODOT_ANDROID_SIGN_PASSWORD=''


### PR DESCRIPTION
- Address step 3 in https://github.com/godotengine/godot-proposals/issues/4230
- Add environment variables to sign the Godot Android Editor release build

**Note:** Should be merged alongside https://github.com/godotengine/godot/pull/74569

[3.x version](https://github.com/godotengine/godot-build-scripts/pull/79)