### PR TITLE
[3.x] Add logic to upload the Godot Android library to MavenCentral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# User-specific configuration and signing key
+# User-specific configuration and signing keys
 config.sh
+*.jks
 *.pfx
 *.pkcs12
 

--- a/build-android/upload-mavencentral.sh
+++ b/build-android/upload-mavencentral.sh
@@ -1,0 +1,18 @@
+#/bin/bash
+
+basedir="$(pwd)"
+
+if [ ! -d "${basedir}/deps/keystore" ]; then
+  echo "Couldn't find ${basedir}/deps/keystore. Make sure to run this from the root folder of the Git repository."
+fi
+
+source ${basedir}/deps/keystore/config.sh
+
+# Release the Godot Android library to MavenCentral
+${PODMAN} run -it --rm \
+  -v ${basedir}/out/android/source:/root/godot -v ${basedir}/deps/keystore:/root/keystore \
+  localhost/godot-android:${IMAGE_VERSION} bash -c \
+    "source /root/keystore/config.sh && \
+    cp -r /root/godot/.gradle /root && \
+    cd /root/godot/platform/android/java && \
+    ./gradlew publishTemplateReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository"

--- a/build-release.sh
+++ b/build-release.sh
@@ -287,6 +287,8 @@ if [ "${build_classical}" == "1" ]; then
   # Editor
   binname="${godot_basename}_android_editor.apk"
   cp out/android/tools/android_editor.apk ${reldir}/${binname}
+  binname="${godot_basename}_android_editor.aab"
+  cp out/android/tools/android_editor.aab ${reldir}/${binname}
 
   # Templates
   cp out/android/templates/*.apk ${templatesdir}/

--- a/config.sh.in
+++ b/config.sh.in
@@ -3,16 +3,28 @@
 # Configuration file for user-specific details.
 # This file is gitignore'd and will be sourced by build scripts.
 
+# Note: For passwords or GPG keys, make sure that special characters such
+# as $ won't be expanded, by using single quotes to enclose the string,
+# or escaping with \$.
+
+# These scripts are designed and tested against podman. They may also work
+# with docker, but it's not guaranteed. You can set this variable to the
+# relevant tool in your PATH or an absolute path to run it from.
+export PODMAN='podman'
+
 # Registry for build containers.
 # The default registry is the one used for official Godot builds.
 # Note that some of its images are private and only accessible to selected
 # contributors.
 # You can build your own registry with scripts at
 # https://github.com/godotengine/build-containers
-export REGISTRY="registry.prehensile-tales.com"
+export REGISTRY='registry.prehensile-tales.com'
+
+# Version string of the images to use in build.sh.
+export IMAGE_VERSION='3.x-f36-mono-6.12.0.182'
 
 # Default build name used to distinguish between official and custom builds.
-export BUILD_NAME="custom_build"
+export BUILD_NAME='custom_build'
 
 # Default number of parallel cores for each build.
 export NUM_CORES=16
@@ -21,24 +33,45 @@ export NUM_CORES=16
 # If you do not fill all SIGN_* fields, signing will be skipped.
 
 # Path to pkcs12 archive.
-export SIGN_KEYSTORE=""
+export SIGN_KEYSTORE=''
 
 # Password for the private key.
-export SIGN_PASSWORD=""
+export SIGN_PASSWORD=''
 
 # Name and URL of the signed application.
 # Use your own when making a thirdparty build.
-export SIGN_NAME=""
-export SIGN_URL=""
+export SIGN_NAME=''
+export SIGN_URL=''
 
 # Hostname or IP address of an OSX host (Needed for signing)
-# eg "user@10.1.0.10"
-export OSX_HOST=""
+# eg 'user@10.1.0.10'
+export OSX_HOST=''
 # ID of the Apple certificate used to sign
-export OSX_KEY_ID=""
+export OSX_KEY_ID=''
 # Bundle id for the signed app
-export OSX_BUNDLE_ID=""
+export OSX_BUNDLE_ID=''
 # Username/password for Apple's signing APIs (used for atltool)
-export APPLE_ID=""
-export APPLE_ID_PASSWORD=""
+export APPLE_ID=''
+export APPLE_ID_PASSWORD=''
 
+# MavenCentral (sonatype) credentials
+export OSSRH_GROUP_ID=''
+export OSSRH_USERNAME=''
+export OSSRH_PASSWORD=''
+# Sonatype assigned ID used to upload the generated artifacts
+export SONATYPE_STAGING_PROFILE_ID=''
+# Used to sign the artifacts after they're built
+# ID of the GPG key pair, the last eight characters of its fingerprint
+export SIGNING_KEY_ID=''
+# Passphrase of the key pair
+export SIGNING_PASSWORD=''
+# Base64 encoded private GPG key
+export SIGNING_KEY=''
+
+# Android signing configs
+# Path to the Android keystore file used to sign the release build
+export GODOT_ANDROID_SIGN_KEYSTORE=''
+# Key alias used for signing the release build
+export GODOT_ANDROID_KEYSTORE_ALIAS=''
+# Password for the key used for signing the release build
+export GODOT_ANDROID_SIGN_PASSWORD=''


### PR DESCRIPTION
- Address step 3 in https://github.com/godotengine/godot-proposals/issues/4230
- Add environment variables to sign the Godot Android Editor release build

**Note:** Should be merged alongside https://github.com/godotengine/godot/pull/74583

[main version](https://github.com/godotengine/godot-build-scripts/pull/78)