### PR TITLE
.NET: Add support for Android builds

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -88,9 +88,7 @@ fi
 
 # Mono
 
-# No Android support with .NET 6 yet.
-#if [ "${MONO}" == "1" ]; then
-if false; then
+if [ "${MONO}" == "1" ]; then
   echo "Starting Mono build for Android..."
 
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
@@ -115,7 +113,7 @@ if false; then
   cp bin/android_source.zip /root/out/templates-mono/
   cp bin/android_debug.apk /root/out/templates-mono/
   cp bin/android_release.apk /root/out/templates-mono/
-  cp bin/godot-lib.release.aar /root/out/templates-mono/
+  cp bin/godot-lib.template_release.aar /root/out/templates-mono/
 fi
 
 echo "Android build successful"

--- a/build-release.sh
+++ b/build-release.sh
@@ -490,6 +490,15 @@ if [ "${build_mono}" == "1" ]; then
   rm -rf macos_template.app
   sign_macos_template ${templatesdir_mono} 1
 
+  ## Android (Mono) ##
+
+  # Lib for direct download
+  cp out/android/templates-mono/godot-lib.template_release.aar ${reldir_mono}/godot-lib.${templates_version}.mono.template_release.aar
+
+  # Templates
+  cp out/android/templates-mono/*.apk ${templatesdir_mono}/
+  cp out/android/templates-mono/android_source.zip ${templatesdir_mono}/
+
   # No .NET support for those platforms yet.
 
   if false; then
@@ -499,15 +508,6 @@ if [ "${build_mono}" == "1" ]; then
   # Templates
   cp out/web/templates-mono/godot.web.template_debug.wasm32.mono.zip ${templatesdir_mono}/web_debug.zip
   cp out/web/templates-mono/godot.web.template_release.wasm32.mono.zip ${templatesdir_mono}/web_release.zip
-
-  ## Android (Mono) ##
-
-  # Lib for direct download
-  cp out/android/templates-mono/godot-lib.template_release.aar ${reldir_mono}/godot-lib.${templates_version}.mono.template_release.aar
-
-  # Templates
-  cp out/android/templates-mono/*.apk ${templatesdir_mono}/
-  cp out/android/templates-mono/android_source.zip ${templatesdir_mono}/
 
   ## iOS (Mono) ##
 


### PR DESCRIPTION
4.2+ only as it depends on https://github.com/godotengine/godot/pull/73257.

That means I'll branch off the previous commit 21af2c7666528dd020c3ce18a3e1043ca1fc56e9 as `4.1` (and `4.0`) and keep using the matching container (Fedora 36 based) for 4.0.x and 4.1.x releases.