### PR TITLE
.NET: Add support for iOS builds

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -57,9 +57,7 @@ fi
 
 # Mono
 
-# No iOS support with .NET 6 yet.
-#if [ "${MONO}" == "1" ]; then
-if false; then
+if [ "${MONO}" == "1" ]; then
   echo "Starting Mono build for iOS..."
 
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/

--- a/build-release.sh
+++ b/build-release.sh
@@ -462,16 +462,6 @@ if [ "${build_mono}" == "1" ]; then
   cp out/android/templates-mono/*.apk ${templatesdir_mono}/
   cp out/android/templates-mono/android_source.zip ${templatesdir_mono}/
 
-  # No .NET support for those platforms yet.
-
-  if false; then
-
-  ## Web (Mono) ##
-
-  # Templates
-  cp out/web/templates-mono/godot.web.template_debug.wasm32.mono.zip ${templatesdir_mono}/web_debug.zip
-  cp out/web/templates-mono/godot.web.template_release.wasm32.mono.zip ${templatesdir_mono}/web_release.zip
-
   ## iOS (Mono) ##
 
   rm -rf ios_xcode
@@ -486,6 +476,16 @@ if [ "${build_mono}" == "1" ]; then
   zip -q -9 -r "${templatesdir_mono}/ios.zip" *
   cd ..
   rm -rf ios_xcode
+
+  # No .NET support for those platforms yet.
+
+  if false; then
+
+  ## Web (Mono) ##
+
+  # Templates
+  cp out/web/templates-mono/godot.web.template_debug.wasm32.mono.zip ${templatesdir_mono}/web_debug.zip
+  cp out/web/templates-mono/godot.web.template_release.wasm32.mono.zip ${templatesdir_mono}/web_release.zip
 
   fi
 


### PR DESCRIPTION
Draft as it depends on https://github.com/godotengine/godot/pull/82729 being merged.

Tested successfully with this build: https://downloads.tuxfamily.org/godotengine/testing/4.2-dev6+pr82729/mono/