### PR TITLE
Publish Android library from the main build-release script

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+export basedir=$(pwd)
 
 # Config
 
@@ -104,6 +105,21 @@ publish_nuget_packages() {
   done
 }
 
+can_publish_maven=0
+if [ ! -d "${basedir}/deps/keystore" ]; then
+  echo "Disabling Android library publishing as ${basedir}/deps/keystore doesn't exist."
+else
+  can_publish_maven=1
+fi
+
+publish_maven_library() {
+  if [ $can_publish_maven == 0 ]; then
+    return
+  fi
+  # FIXME: Might be worth reworking the script to make it all sudo-safe and use appropriate users throughout.
+  sudo sh build-android/upload-mavencentral.sh
+}
+
 godot_version=""
 templates_version=""
 do_cleanup=1
@@ -111,8 +127,9 @@ make_tarball=1
 build_classical=1
 build_mono=1
 publish_nuget=0
+publish_maven=0
 
-while getopts "h?v:t:b:n-:" opt; do
+while getopts "h?v:t:b:p:n-:" opt; do
   case "$opt" in
   h|\?)
     echo "Usage: $0 [OPTIONS...]"
@@ -120,7 +137,7 @@ while getopts "h?v:t:b:n-:" opt; do
     echo "  -v godot version (e.g: 3.2-stable) [mandatory]"
     echo "  -t templates version (e.g. 3.2.stable) [mandatory]"
     echo "  -b build target: all|classical|mono|none (default: all)"
-    echo "  -n publish nuget packages (default: false)"
+    echo "  -p publish target: all|nuget|maven|none (default: none)"
     echo "  --no-cleanup disable deleting pre-existing output folders (default: false)"
     echo "  --no-tarball disable generating source tarball (default: false)"
     echo
@@ -142,8 +159,15 @@ while getopts "h?v:t:b:n-:" opt; do
       build_mono=0
     fi
     ;;
-  n)
-    publish_nuget=1
+  p)
+    if [ "$OPTARG" == "nuget" ]; then
+      publish_nuget=1
+    elif [ "$OPTARG" == "maven" ]; then
+      publish_maven=1
+    elif [ "$OPTARG" == "all" ]; then
+      publish_nuget=1
+      publish_maven=1
+    fi
     ;;
   -)
     case "${OPTARG}" in
@@ -172,7 +196,6 @@ elif [[ "{$templates_version}" == *"-"* ]]; then
   exit 1
 fi
 
-export basedir=$(pwd)
 export webdir="${basedir}/web/${templates_version}"
 export reldir="${basedir}/releases/${godot_version}"
 export reldir_mono="${reldir}/mono"
@@ -512,6 +535,15 @@ if [ "${publish_nuget}" == "1" ]; then
 
   echo "Publishing NuGet packages..."
   publish_nuget_packages out/linux/x86_64/tools-mono/GodotSharp/Tools/nupkgs/*.nupkg
+
+fi
+
+# Godot Android library
+
+if [ "${publish_maven}" == "1" ]; then
+
+  echo "Publishing Android library to MavenCentral..."
+  publish_maven_library
 
 fi
 

--- a/clean-release.sh
+++ b/clean-release.sh
@@ -1,2 +1,3 @@
-rm -rf releases tmp web
+#!/bin/bash
 
+rm -rf releases tmp web

--- a/clean.sh
+++ b/clean.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 rm -rf godot*.tar.gz mono-glue out releases tmp web
 git status


### PR DESCRIPTION
This is a requirement for all current versions of Godot, both stable and pre-releases. I unified this new option with the old one to publish nuget packages, as it all seems related. (Old `-n` options is kept for compatibility.)

I haven't tested this, not really sure how, but I think it should be pretty straight-forward.