### PR TITLE
Android: Install JDK 17 needed for 4.2-beta2 and later

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -18,6 +18,9 @@ tar xf /root/godot.tar.gz --strip-components=1
 # as well as signing and publishing to MavenCentral.
 source /root/keystore/config.sh
 
+# Temporary, until we make new build containers.
+dnf install -y java-17-openjdk-devel
+
 store_release="yes"
 if [ -z "${GODOT_ANDROID_SIGN_KEYSTORE}" ]; then
   echo "No keystore provided to sign the Android release editor build, using debug build instead."

--- a/build-android/upload-mavencentral.sh
+++ b/build-android/upload-mavencentral.sh
@@ -13,6 +13,7 @@ ${PODMAN} run -it --rm \
   -v ${basedir}/out/android/source:/root/godot -v ${basedir}/deps/keystore:/root/keystore \
   localhost/godot-android:${IMAGE_VERSION} bash -c \
     "source /root/keystore/config.sh && \
+    dnf install -y java-17-openjdk-devel && \
     cp -r /root/godot/.gradle /root && \
     cd /root/godot/platform/android/java && \
     ./gradlew publishTemplateReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository"

--- a/build-web/build.sh
+++ b/build-web/build.sh
@@ -8,7 +8,7 @@ set -e
 # we run all builds in parallel each from their own folder.
 export NUM_JOBS=5
 declare -a JOBS=(
-  "target=editor use_closure_compiler=yes"
+  "target=editor use_closure_compiler=no"
   "target=template_debug"
   "target=template_release"
   "target=template_debug dlink_enabled=yes"


### PR DESCRIPTION
Temporary change until we switch to newer build containers with it.

Also temporarily disable closure compiler for Web editor, needed for 4.2 beta 1 and beta 2, should be fixed upstream afterwarads.