### PR TITLE
Update scripts for new Fedora 39 based images for 4.2-beta3 and later

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -18,9 +18,6 @@ tar xf /root/godot.tar.gz --strip-components=1
 # as well as signing and publishing to MavenCentral.
 source /root/keystore/config.sh
 
-# Temporary, until we make new build containers.
-dnf install -y java-17-openjdk-devel
-
 store_release="yes"
 if [ -z "${GODOT_ANDROID_SIGN_KEYSTORE}" ]; then
   echo "No keystore provided to sign the Android release editor build, using debug build instead."
@@ -28,8 +25,6 @@ if [ -z "${GODOT_ANDROID_SIGN_KEYSTORE}" ]; then
 fi
 
 # Classical
-
-dnf -y install gettext
 
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for Android..."

--- a/build-android/upload-mavencentral.sh
+++ b/build-android/upload-mavencentral.sh
@@ -13,7 +13,6 @@ ${PODMAN} run -it --rm \
   -v ${basedir}/out/android/source:/root/godot -v ${basedir}/deps/keystore:/root/keystore \
   localhost/godot-android:${IMAGE_VERSION} bash -c \
     "source /root/keystore/config.sh && \
-    dnf install -y java-17-openjdk-devel && \
     cp -r /root/godot/.gradle /root && \
     cd /root/godot/platform/android/java && \
     ./gradlew publishTemplateReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository"

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -11,7 +11,7 @@ export OPTIONS="production=yes use_lto=no"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
-export IOS_SDK="16.1"
+export IOS_SDK="17.0"
 export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
 
 rm -rf godot
@@ -20,8 +20,6 @@ cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
 # Classical
-
-dnf -y install gettext
 
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for iOS..."
@@ -36,15 +34,15 @@ if [ "${CLASSICAL}" == "1" ]; then
   # Disabled for now as it doesn't work with cctools-port and current LLVM.
   # See https://github.com/godotengine/build-containers/pull/85.
   #$SCONS platform=ios $OPTIONS arch=arm64 ios_simulator=yes target=template_debug \
-  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
-  #$SCONS platform=ios $OPTIONS arch=arm64 ios_simulator=no target=template_release \
-  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #$SCONS platform=ios $OPTIONS arch=arm64 ios_simulator=yes target=template_release \
+  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
 
   # x86_64 simulator
   $SCONS platform=ios $OPTIONS arch=x86_64 ios_simulator=yes target=template_debug \
-    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
   $SCONS platform=ios $OPTIONS arch=x86_64 ios_simulator=yes target=template_release \
-    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
 
   mkdir -p /root/out/templates
   cp bin/libgodot.ios.template_release.arm64.a /root/out/templates/libgodot.ios.a
@@ -72,15 +70,15 @@ if [ "${MONO}" == "1" ]; then
   # Disabled for now as it doesn't work with cctools-port and current LLVM.
   # See https://github.com/godotengine/build-containers/pull/85.
   #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes target=template_debug \
-  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
   #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes target=template_release \
-  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
 
   # x86_64 simulator
   $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes target=template_debug \
-    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
   $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes target=template_release \
-    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
 
   mkdir -p /root/out/templates-mono
 

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -17,8 +17,6 @@ tar xf /root/godot.tar.gz --strip-components=1
 # pkg-config wrongly points to lib instead of lib64 for arch-dependent header.
 sed -i ${GODOT_SDK_LINUX_X86_64}/x86_64-godot-linux-gnu/sysroot/usr/lib/pkgconfig/dbus-1.pc -e "s@/lib@/lib64@g"
 
-dnf -y install gettext
-
 # Classical
 
 if [ "${CLASSICAL}" == "1" ]; then

--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -5,9 +5,9 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="osxcross_sdk=darwin22 production=yes use_volk=no vulkan_sdk_path=/root/vulkansdk angle_libs=/root/angle"
+export OPTIONS="osxcross_sdk=darwin23 production=yes use_volk=no vulkan_sdk_path=/root/vulkansdk angle_libs=/root/angle"
 export OPTIONS_MONO="module_mono_enabled=yes"
-export STRIP="x86_64-apple-darwin22-strip -u -r"
+export STRIP="x86_64-apple-darwin23-strip -u -r"
 export TERM=xterm
 
 rm -rf godot
@@ -16,8 +16,6 @@ cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
 # Classical
-
-dnf -y install gettext
 
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for macOS..."

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -18,10 +18,6 @@ tar xf ../godot.tar.gz --strip-components=1
 # pkg-config wrongly points to lib instead of lib64 for arch-dependent header.
 sed -i ${GODOT_SDK_LINUX_X86_64}/x86_64-godot-linux-gnu/sysroot/usr/lib/pkgconfig/dbus-1.pc -e "s@/lib@/lib64@g"
 
-# Temporarily until we make --headless mode actually skip X11.
-dnf install -y libX11 libXcursor libXrandr libXinerama libXi mesa-libGL
-dnf -y install gettext
-
 # Mono
 
 if [ "${MONO}" == "1" ]; then

--- a/build-web/build.sh
+++ b/build-web/build.sh
@@ -8,7 +8,7 @@ set -e
 # we run all builds in parallel each from their own folder.
 export NUM_JOBS=5
 declare -a JOBS=(
-  "target=editor use_closure_compiler=no"
+  "target=editor use_closure_compiler=yes"
   "target=template_debug"
   "target=template_release"
   "target=template_debug dlink_enabled=yes"
@@ -28,8 +28,6 @@ cd godot
 tar xf /root/godot.tar.gz --strip-components=1
 
 # Classical
-
-dnf -y install gettext
 
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for Web..."

--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -16,8 +16,6 @@ tar xf /root/godot.tar.gz --strip-components=1
 
 # Classical
 
-dnf -y install gettext
-
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for Windows..."
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/build-containers/pull/128.

Also reverts #88 since these new images include JDK 17, and the closure compiler issue was fixed upstream.

And removes the manual install of gettext which is now also part of the images.

X11 libs should not be needed to generate the Mono glue anymore (they've been unnecessary for a while already).