### PR TITLE
Linux: Disable LTO for ARM64/ARM32, it crashes on Raspberry Pi OS

### DIFF
--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -7,6 +7,7 @@ set -e
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes"
+export OPTIONS_ARM="lto=none"
 export TERM=xterm
 
 rm -rf godot
@@ -47,26 +48,26 @@ if [ "${CLASSICAL}" == "1" ]; then
 
   export PATH="${GODOT_SDK_LINUX_ARM64}/bin:${BASE_PATH}"
 
-  $SCONS platform=linuxbsd arch=arm64 $OPTIONS target=editor
+  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_ARM target=editor
   mkdir -p /root/out/arm64/tools
   cp -rvp bin/* /root/out/arm64/tools
   rm -rf bin
 
-  $SCONS platform=linuxbsd arch=arm64 $OPTIONS target=template_debug
-  $SCONS platform=linuxbsd arch=arm64 $OPTIONS target=template_release
+  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_ARM target=template_debug
+  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_ARM target=template_release
   mkdir -p /root/out/arm64/templates
   cp -rvp bin/* /root/out/arm64/templates
   rm -rf bin
 
   export PATH="${GODOT_SDK_LINUX_ARM32}/bin:${BASE_PATH}"
 
-  $SCONS platform=linuxbsd arch=arm32 $OPTIONS target=editor
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_ARM target=editor
   mkdir -p /root/out/arm32/tools
   cp -rvp bin/* /root/out/arm32/tools
   rm -rf bin
 
-  $SCONS platform=linuxbsd arch=arm32 $OPTIONS target=template_debug
-  $SCONS platform=linuxbsd arch=arm32 $OPTIONS target=template_release
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_ARM target=template_debug
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_ARM target=template_release
   mkdir -p /root/out/arm32/templates
   cp -rvp bin/* /root/out/arm32/templates
   rm -rf bin
@@ -110,28 +111,28 @@ if [ "${MONO}" == "1" ]; then
 
   export PATH="${GODOT_SDK_LINUX_ARM64}/bin:${BASE_PATH}"
 
-  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_MONO target=editor
+  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_MONO $OPTIONS_ARM target=editor
   ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
   mkdir -p /root/out/arm64/tools-mono
   cp -rvp bin/* /root/out/arm64/tools-mono
   rm -rf bin
 
-  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_MONO target=template_debug
-  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_MONO target=template_release
+  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_MONO $OPTIONS_ARM target=template_debug
+  $SCONS platform=linuxbsd arch=arm64 $OPTIONS $OPTIONS_MONO $OPTIONS_ARM target=template_release
   mkdir -p /root/out/arm64/templates-mono
   cp -rvp bin/* /root/out/arm64/templates-mono
   rm -rf bin
 
   export PATH="${GODOT_SDK_LINUX_ARM32}/bin:${BASE_PATH}"
 
-  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_MONO target=editor
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_MONO $OPTIONS_ARM target=editor
   ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
   mkdir -p /root/out/arm32/tools-mono
   cp -rvp bin/* /root/out/arm32/tools-mono
   rm -rf bin
 
-  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_MONO target=template_debug
-  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_MONO target=template_release
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_MONO $OPTIONS_ARM target=template_debug
+  $SCONS platform=linuxbsd arch=arm32 $OPTIONS $OPTIONS_MONO $OPTIONS_ARM target=template_release
   mkdir -p /root/out/arm32/templates-mono
   cp -rvp bin/* /root/out/arm32/templates-mono
   rm -rf bin


### PR DESCRIPTION
Needs further investigation and reporting the bug upstream.

Technically I've only tested it to be an issue on ARM64 on a Raspberry Pi 5, but I'm disabling it for ARM32 too to be safe.

@hiulit reported that Ubuntu 23.10 seemed to work fine with our LTO'd binaries, so looking at the differences between RPiOS and Ubuntu 23.10 might help pinpoint what causes the issue.

Might be GCC or glibc bug?