### PR TITLE
[3.x] Update all to new toolchains, add Linux arm64 and arm32 builds

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -11,7 +11,7 @@ export OPTIONS="production=yes lto=none"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export TERM=xterm
 
-export IOS_SDK="15.4"
+export IOS_SDK="17.0"
 export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
 
 rm -rf godot
@@ -34,15 +34,15 @@ if [ "${CLASSICAL}" == "1" ]; then
   # Disabled for now as it doesn't work with cctools-port and current LLVM.
   # See https://github.com/godotengine/build-containers/pull/85.
   #$SCONS platform=iphone $OPTIONS arch=arm64 tools=no ios_simulator=yes target=release_debug \
-  #  IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #  IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
   #$SCONS platform=iphone $OPTIONS arch=arm64 tools=no ios_simulator=no target=release \
-  #  IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #  IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
 
   # x86_64 simulator
   $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no ios_simulator=yes target=release_debug \
-    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
   $SCONS platform=iphone $OPTIONS arch=x86_64 tools=no ios_simulator=yes target=release \
-    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
 
   mkdir -p /root/out/templates
   cp bin/libgodot.iphone.opt.arm64.a /root/out/templates/libgodot.iphone.a
@@ -72,15 +72,15 @@ if [ "${MONO}" == "1" ]; then
   # Disabled for now as it doesn't work with cctools-port and current LLVM.
   # See https://github.com/godotengine/build-containers/pull/85.
   #$SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-arm64-sim-release tools=no target=release_debug \
-  #  IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #  IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
   #$SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-arm64-sim-release tools=no target=release \
-  #  IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #  IPHONESDK="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
 
   # x86_64 simulator
   $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release_debug \
-    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
   $SCONS platform=iphone $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes mono_prefix=/root/mono-installs/ios-x86_64-release tools=no target=release \
-    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneOS${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+    IPHONESDK="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" IPHONEPATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
 
   mkdir -p /root/out/templates-mono
 

--- a/build-linux/build.sh
+++ b/build-linux/build.sh
@@ -5,7 +5,7 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="production=yes"
+export OPTIONS="production=yes LINKFLAGS=-s"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export MONO_PREFIX_X86_64="/root/mono-installs/desktop-linux-x86_64-release"
 export MONO_PREFIX_X86="/root/mono-installs/desktop-linux-x86-release"
@@ -34,17 +34,43 @@ if [ "${CLASSICAL}" == "1" ]; then
   cp -rvp bin/* /root/out/x64/templates
   rm -rf bin
 
-  export PATH="${GODOT_SDK_LINUX_X86}/bin:${BASE_PATH}"
+  export PATH="${GODOT_SDK_LINUX_X86_32}/bin:${BASE_PATH}"
 
-  $SCONS platform=x11 $OPTIONS tools=yes target=release_debug bits=32
+  $SCONS platform=x11 bits=32 $OPTIONS tools=yes target=release_debug
   mkdir -p /root/out/x86/tools
   cp -rvp bin/* /root/out/x86/tools
   rm -rf bin
 
-  $SCONS platform=x11 $OPTIONS tools=no target=release_debug bits=32
-  $SCONS platform=x11 $OPTIONS tools=no target=release bits=32
+  $SCONS platform=x11 bits=32 $OPTIONS tools=no target=release_debug
+  $SCONS platform=x11 bits=32 $OPTIONS tools=no target=release
   mkdir -p /root/out/x86/templates
   cp -rvp bin/* /root/out/x86/templates
+  rm -rf bin
+
+  export PATH="${GODOT_SDK_LINUX_ARM64}/bin:${BASE_PATH}"
+
+  $SCONS platform=x11 arch=arm64 $OPTIONS tools=yes target=release_debug
+  mkdir -p /root/out/arm64/tools
+  cp -rvp bin/* /root/out/arm64/tools
+  rm -rf bin
+
+  $SCONS platform=x11 arch=arm64 $OPTIONS tools=no target=release_debug
+  $SCONS platform=x11 arch=arm64 $OPTIONS tools=no target=release
+  mkdir -p /root/out/arm64/templates
+  cp -rvp bin/* /root/out/arm64/templates
+  rm -rf bin
+
+  export PATH="${GODOT_SDK_LINUX_ARM32}/bin:${BASE_PATH}"
+
+  $SCONS platform=x11 arch=arm $OPTIONS tools=yes target=release_debug
+  mkdir -p /root/out/arm/tools
+  cp -rvp bin/* /root/out/arm/tools
+  rm -rf bin
+
+  $SCONS platform=x11 arch=arm $OPTIONS tools=no target=release_debug
+  $SCONS platform=x11 arch=arm $OPTIONS tools=no target=release
+  mkdir -p /root/out/arm/templates
+  cp -rvp bin/* /root/out/arm/templates
   rm -rf bin
 fi
 
@@ -71,16 +97,16 @@ if [ "${MONO}" == "1" ]; then
   cp -rvp bin/* /root/out/x64/templates-mono
   rm -rf bin
 
-  export PATH="${GODOT_SDK_LINUX_X86}/bin:${BASE_PATH}"
+  export PATH="${GODOT_SDK_LINUX_X86_32}/bin:${BASE_PATH}"
   export OPTIONS_MONO_PREFIX="${OPTIONS} ${OPTIONS_MONO} mono_prefix=${MONO_PREFIX_X86}"
 
-  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes bits=32
+  $SCONS platform=x11 bits=32 $OPTIONS_MONO_PREFIX tools=yes target=release_debug copy_mono_root=yes
   mkdir -p /root/out/x86/tools-mono
   cp -rvp bin/* /root/out/x86/tools-mono
   rm -rf bin
 
-  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=no target=release_debug bits=32
-  $SCONS platform=x11 $OPTIONS_MONO_PREFIX tools=no target=release bits=32
+  $SCONS platform=x11 bits=32 $OPTIONS_MONO_PREFIX tools=no target=release_debug
+  $SCONS platform=x11 bits=32 $OPTIONS_MONO_PREFIX tools=no target=release
   mkdir -p /root/out/x86/templates-mono
   cp -rvp bin/* /root/out/x86/templates-mono
   rm -rf bin

--- a/build-macosx/build.sh
+++ b/build-macosx/build.sh
@@ -5,11 +5,11 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="osxcross_sdk=darwin21.4 production=yes"
+export OPTIONS="osxcross_sdk=darwin23 production=yes"
 export OPTIONS_MONO="module_mono_enabled=yes mono_static=yes"
 export MONO_PREFIX_X86_64="/root/mono-installs/desktop-osx-x86_64-release"
 export MONO_PREFIX_ARM64="/root/mono-installs/desktop-osx-arm64-release"
-export STRIP="x86_64-apple-darwin21.4-strip -u -r"
+export STRIP="x86_64-apple-darwin23-strip -u -r"
 export TERM=xterm
 
 rm -rf godot
@@ -69,7 +69,7 @@ if [ "${MONO}" == "1" ]; then
   $STRIP bin/godot.osx.opt.tools.universal.mono
 
   # Make universal versions of the dylibs we use.
-  lipo -create tmp-lib/x86_64/libmono-native-compat.dylib tmp-lib/arm64/libmono-native.dylib -output tmp-lib/libmono-native.dylib
+  lipo -create tmp-lib/x86_64/libmono-native.dylib tmp-lib/arm64/libmono-native.dylib -output tmp-lib/libmono-native.dylib
   lipo -create tmp-lib/x86_64/libMonoPosixHelper.dylib tmp-lib/arm64/libMonoPosixHelper.dylib -output tmp-lib/libMonoPosixHelper.dylib
   lipo -create tmp-lib/x86_64/libmono-btls-shared.dylib tmp-lib/arm64/libmono-btls-shared.dylib -output tmp-lib/libmono-btls-shared.dylib
 

--- a/build-mono-glue/build.sh
+++ b/build-mono-glue/build.sh
@@ -22,7 +22,7 @@ if [ "${MONO}" == "1" ]; then
   mono --version
   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig/
 
-  ${SCONS} platform=x11 bits=64 ${OPTIONS} target=release_debug tools=yes module_mono_enabled=yes mono_glue=no
+  ${SCONS} platform=x11 ${OPTIONS} target=release_debug tools=yes module_mono_enabled=yes mono_glue=no
 
   rm -rf /root/mono-glue/*
   xvfb-run bin/godot.x11.opt.tools.64.mono --audio-driver Dummy --generate-mono-glue /root/mono-glue || /bin/true

--- a/build-release.sh
+++ b/build-release.sh
@@ -170,13 +170,21 @@ if [ "${build_classical}" == "1" ]; then
   # Editor
   binname="${godot_basename}_x11.64"
   cp out/linux/x64/tools/godot.x11.opt.tools.64 ${binname}
-  strip ${binname}
   zip -q -9 "${reldir}/${binname}.zip" ${binname}
   rm ${binname}
 
   binname="${godot_basename}_x11.32"
   cp out/linux/x86/tools/godot.x11.opt.tools.32 ${binname}
-  strip ${binname}
+  zip -q -9 "${reldir}/${binname}.zip" ${binname}
+  rm ${binname}
+
+  binname="${godot_basename}_linux.arm64"
+  cp out/linux/arm64/tools/godot.x11.opt.tools.arm64 ${binname}
+  zip -q -9 "${reldir}/${binname}.zip" ${binname}
+  rm ${binname}
+
+  binname="${godot_basename}_linux.arm32"
+  cp out/linux/arm/tools/godot.x11.opt.tools.arm ${binname}
   zip -q -9 "${reldir}/${binname}.zip" ${binname}
   rm ${binname}
 
@@ -185,7 +193,10 @@ if [ "${build_classical}" == "1" ]; then
   cp out/linux/x64/templates/godot.x11.opt.debug.64 ${templatesdir}/linux_x11_64_debug
   cp out/linux/x86/templates/godot.x11.opt.32 ${templatesdir}/linux_x11_32_release
   cp out/linux/x86/templates/godot.x11.opt.debug.32 ${templatesdir}/linux_x11_32_debug
-  strip ${templatesdir}/linux_x11_*
+  cp out/linux/arm64/templates/godot.x11.opt.arm64 ${templatesdir}/linux_x11_arm64_release
+  cp out/linux/arm64/templates/godot.x11.opt.debug.arm64 ${templatesdir}/linux_x11_arm64_debug
+  cp out/linux/arm/templates/godot.x11.opt.arm ${templatesdir}/linux_x11_arm32_release
+  cp out/linux/arm/templates/godot.x11.opt.debug.arm ${templatesdir}/linux_x11_arm32_debug
 
   ## Windows (Classical) ##
 
@@ -370,7 +381,6 @@ if [ "${build_mono}" == "1" ]; then
   binbasename="${godot_basename}_mono_x11"
   mkdir -p ${binbasename}_64
   cp out/linux/x64/tools-mono/godot.x11.opt.tools.64.mono ${binbasename}_64/${binbasename}.64
-  strip ${binbasename}_64/${binbasename}.64
   cp -rp out/linux/x64/tools-mono/GodotSharp ${binbasename}_64/
   cp -rp out/aot-compilers ${binbasename}_64/GodotSharp/Tools/
   zip -r -q -9 "${reldir_mono}/${binbasename}_64.zip" ${binbasename}_64
@@ -379,7 +389,6 @@ if [ "${build_mono}" == "1" ]; then
   binbasename="${godot_basename}_mono_x11"
   mkdir -p ${binbasename}_32
   cp out/linux/x86/tools-mono/godot.x11.opt.tools.32.mono ${binbasename}_32/${binbasename}.32
-  strip ${binbasename}_32/${binbasename}.32
   cp -rp out/linux/x86/tools-mono/GodotSharp/ ${binbasename}_32/
   cp -rp out/aot-compilers ${binbasename}_32/GodotSharp/Tools/
   zip -r -q -9 "${reldir_mono}/${binbasename}_32.zip" ${binbasename}_32
@@ -392,7 +401,6 @@ if [ "${build_mono}" == "1" ]; then
   cp -rp out/linux/x86/templates-mono/data.mono.x11.32.* ${templatesdir_mono}/
   cp out/linux/x86/templates-mono/godot.x11.opt.debug.32.mono ${templatesdir_mono}/linux_x11_32_debug
   cp out/linux/x86/templates-mono/godot.x11.opt.32.mono ${templatesdir_mono}/linux_x11_32_release
-  strip ${templatesdir_mono}/linux_x11*
 
   mkdir -p ${templatesdir_mono}/bcl
   cp -r out/linux/x64/tools-mono/GodotSharp/Mono/lib/mono/4.5/ ${templatesdir_mono}/bcl/net_4_x


### PR DESCRIPTION
Backport of #89 and #90, in sync with https://github.com/godotengine/build-containers/pull/135.

In the 3.x branch, the situation with `arch` and `bits` is very brittle, so we only add the explicit `arch` argument for the arm32/arm64 builds. x86_32 still relies on `bits=32`.

This would all be worth refactoring upstream like we did for 4.0, but it's a major undertaking and breaking change, which I'd prefer to avoid in 3.6.

For Linux builds, we move the `strip` calls to the link stage, as this
needs to be done with the arch-appropriate `strip` binary, so it's easier
done there. In `master`, we now let the compiler strip automatically
during the build if no debug symbols are requested, but this change
wasn't backported to 3.x.

---

Tested successfully for almost all platforms, I'm just battling some final issues with Linux arm32 (https://github.com/godotengine/godot/pull/87258, and it looks like our buildroot will need to change its config to enable NEON intrinsics).

This is meant to be used with `3.x-f39-mono-6.12.0.198` containers built from https://github.com/godotengine/build-containers/pull/135.