### PR TITLE
Don't strip Windows and macOS binaries, already done at build time

### DIFF
--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -7,7 +7,6 @@ set -e
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
 export OPTIONS="osxcross_sdk=darwin23.6 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle"
 export OPTIONS_MONO="module_mono_enabled=yes"
-export STRIP="x86_64-apple-darwin23.6-strip -u -r"
 export TERM=xterm
 
 rm -rf godot
@@ -23,7 +22,6 @@ if [ "${CLASSICAL}" == "1" ]; then
   $SCONS platform=macos $OPTIONS arch=x86_64 target=editor
   $SCONS platform=macos $OPTIONS arch=arm64 target=editor
   lipo -create bin/godot.macos.editor.x86_64 bin/godot.macos.editor.arm64 -output bin/godot.macos.editor.universal
-  $STRIP bin/godot.macos.editor.universal
 
   mkdir -p /root/out/tools
   cp -rvp bin/* /root/out/tools
@@ -32,11 +30,9 @@ if [ "${CLASSICAL}" == "1" ]; then
   $SCONS platform=macos $OPTIONS arch=x86_64 target=template_debug
   $SCONS platform=macos $OPTIONS arch=arm64 target=template_debug
   lipo -create bin/godot.macos.template_debug.x86_64 bin/godot.macos.template_debug.arm64 -output bin/godot.macos.template_debug.universal
-  $STRIP bin/godot.macos.template_debug.universal
   $SCONS platform=macos $OPTIONS arch=x86_64 target=template_release
   $SCONS platform=macos $OPTIONS arch=arm64 target=template_release
   lipo -create bin/godot.macos.template_release.x86_64 bin/godot.macos.template_release.arm64 -output bin/godot.macos.template_release.universal
-  $STRIP bin/godot.macos.template_release.universal
 
   mkdir -p /root/out/templates
   cp -rvp bin/* /root/out/templates
@@ -54,7 +50,6 @@ if [ "${MONO}" == "1" ]; then
   $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=editor
   $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=editor
   lipo -create bin/godot.macos.editor.x86_64.mono bin/godot.macos.editor.arm64.mono -output bin/godot.macos.editor.universal.mono
-  $STRIP bin/godot.macos.editor.universal.mono
   ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=macos
 
   mkdir -p /root/out/tools-mono
@@ -64,11 +59,9 @@ if [ "${MONO}" == "1" ]; then
   $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_debug
   $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug
   lipo -create bin/godot.macos.template_debug.x86_64.mono bin/godot.macos.template_debug.arm64.mono -output bin/godot.macos.template_debug.universal.mono
-  $STRIP bin/godot.macos.template_debug.universal.mono
   $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_release
   $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release
   lipo -create bin/godot.macos.template_release.x86_64.mono bin/godot.macos.template_release.arm64.mono -output bin/godot.macos.template_release.universal.mono
-  $STRIP bin/godot.macos.template_release.universal.mono
 
   mkdir -p /root/out/templates-mono
   cp -rvp bin/* /root/out/templates-mono

--- a/build-release.sh
+++ b/build-release.sh
@@ -274,10 +274,8 @@ if [ "${build_classical}" == "1" ]; then
   binname="${godot_basename}_win64.exe"
   wrpname="${godot_basename}_win64_console.exe"
   cp out/windows/x86_64/tools/godot.windows.editor.x86_64.exe ${binname}
-  strip ${binname}
   sign_windows ${binname}
   cp out/windows/x86_64/tools/godot.windows.editor.x86_64.console.exe ${wrpname}
-  strip ${wrpname}
   sign_windows ${wrpname}
   zip -q -9 "${reldir}/${binname}.zip" ${binname} ${wrpname}
   rm ${binname} ${wrpname}
@@ -285,10 +283,8 @@ if [ "${build_classical}" == "1" ]; then
   binname="${godot_basename}_win32.exe"
   wrpname="${godot_basename}_win32_console.exe"
   cp out/windows/x86_32/tools/godot.windows.editor.x86_32.exe ${binname}
-  strip ${binname}
   sign_windows ${binname}
   cp out/windows/x86_32/tools/godot.windows.editor.x86_32.console.exe ${wrpname}
-  strip ${wrpname}
   sign_windows ${wrpname}
   zip -q -9 "${reldir}/${binname}.zip" ${binname} ${wrpname}
   rm ${binname} ${wrpname}
@@ -302,7 +298,6 @@ if [ "${build_classical}" == "1" ]; then
   cp out/windows/x86_64/templates/godot.windows.template_debug.x86_64.console.exe ${templatesdir}/windows_debug_x86_64_console.exe
   cp out/windows/x86_32/templates/godot.windows.template_release.x86_32.console.exe ${templatesdir}/windows_release_x86_32_console.exe
   cp out/windows/x86_32/templates/godot.windows.template_debug.x86_32.console.exe ${templatesdir}/windows_debug_x86_32_console.exe
-  strip ${templatesdir}/windows*.exe
 
   ## macOS (Classical) ##
 
@@ -449,11 +444,9 @@ if [ "${build_mono}" == "1" ]; then
   wrpname="${godot_basename}_mono_win64_console"
   mkdir -p ${binname}
   cp out/windows/x86_64/tools-mono/godot.windows.editor.x86_64.mono.exe ${binname}/${binname}.exe
-  strip ${binname}/${binname}.exe
   sign_windows ${binname}/${binname}.exe
   cp -rp out/windows/x86_64/tools-mono/GodotSharp ${binname}/
   cp out/windows/x86_64/tools-mono/godot.windows.editor.x86_64.mono.console.exe ${binname}/${wrpname}.exe
-  strip ${binname}/${wrpname}.exe
   sign_windows ${binname}/${wrpname}.exe
   zip -r -q -9 "${reldir_mono}/${binname}.zip" ${binname}
   rm -rf ${binname}
@@ -462,11 +455,9 @@ if [ "${build_mono}" == "1" ]; then
   wrpname="${godot_basename}_mono_win32_console"
   mkdir -p ${binname}
   cp out/windows/x86_32/tools-mono/godot.windows.editor.x86_32.mono.exe ${binname}/${binname}.exe
-  strip ${binname}/${binname}.exe
   sign_windows ${binname}/${binname}.exe
   cp -rp out/windows/x86_32/tools-mono/GodotSharp ${binname}/
   cp out/windows/x86_32/tools-mono/godot.windows.editor.x86_32.mono.console.exe ${binname}/${wrpname}.exe
-  strip ${binname}/${wrpname}.exe
   sign_windows ${binname}/${wrpname}.exe
   zip -r -q -9 "${reldir_mono}/${binname}.zip" ${binname}
   rm -rf ${binname}
@@ -480,7 +471,6 @@ if [ "${build_mono}" == "1" ]; then
   cp out/windows/x86_64/templates-mono/godot.windows.template_release.x86_64.mono.console.exe ${templatesdir_mono}/windows_release_x86_64_console.exe
   cp out/windows/x86_32/templates-mono/godot.windows.template_debug.x86_32.mono.console.exe ${templatesdir_mono}/windows_debug_x86_32_console.exe
   cp out/windows/x86_32/templates-mono/godot.windows.template_release.x86_32.mono.console.exe ${templatesdir_mono}/windows_release_x86_32_console.exe
-  strip ${templatesdir_mono}/windows*.exe
 
   ## macOS (Mono) ##
 


### PR DESCRIPTION
Already removed for Linux in #90.