### PR TITLE
Windows: Add extra editor build with `steamapi=yes` for stable releases

### DIFF
--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -52,6 +52,17 @@ if [ "${CLASSICAL}" == "1" ]; then
   mkdir -p /root/out/arm64/templates
   cp -rvp bin/* /root/out/arm64/templates
   rm -rf bin
+
+  if [ "${STEAM}" == "1" ]; then
+    build_name=${BUILD_NAME}
+    export BUILD_NAME="steam"
+    $SCONS platform=windows arch=x86_64 $OPTIONS target=editor steamapi=yes
+    $SCONS platform=windows arch=x86_32 $OPTIONS target=editor steamapi=yes
+    mkdir -p /root/out/steam
+    cp -rvp bin/* /root/out/steam
+    rm -rf bin
+    export BUILD_NAME=${build_name}
+  fi
 fi
 
 # Mono

--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,7 @@ godot_version=""
 git_treeish="master"
 build_classical=1
 build_mono=1
+build_steam=0
 force_download=0
 skip_download=1
 skip_git_checkout=0
@@ -99,6 +100,10 @@ case "$choice" in
   * ) echo "Invalid choice, aborting."; exit 1;;
 esac
 export GODOT_VERSION_STATUS="${status}"
+
+if [ "${status}" == "stable" ]; then
+  build_steam=1
+fi
 
 if [ ! -z "${username}" ] && [ ! -z "${password}" ]; then
   if ${podman} login ${registry} -u "${username}" -p "${password}"; then
@@ -226,7 +231,7 @@ mkdir -p ${basedir}/mono-glue
 ${podman_run} -v ${basedir}/build-mono-glue:/root/build localhost/godot-linux:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/mono-glue
 
 mkdir -p ${basedir}/out/windows
-${podman_run} -v ${basedir}/build-windows:/root/build -v ${basedir}/out/windows:/root/out -v ${basedir}/deps/angle:/root/angle -v ${basedir}/deps/mesa:/root/mesa localhost/godot-windows:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/windows
+${podman_run} -v ${basedir}/build-windows:/root/build -v ${basedir}/out/windows:/root/out -v ${basedir}/deps/angle:/root/angle -v ${basedir}/deps/mesa:/root/mesa --env STEAM=${build_steam} localhost/godot-windows:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/windows
 
 mkdir -p ${basedir}/out/linux
 ${podman_run} -v ${basedir}/build-linux:/root/build -v ${basedir}/out/linux:/root/out localhost/godot-linux:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/linux


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/79126 to finally make it active on Steam builds.

The other option would be to enable this option for the generic Windows builds, but we haven't tested this much during beta/RC and I'm not too keen on having the binary always probe for steamapi for the majority of users who don't use Godot through Steam.