### PR TITLE
Update toolchains based on Fedora 41 for Godot 4.4

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -11,7 +11,7 @@ export OPTIONS="production=yes use_lto=no"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
-export IOS_SDK="17.5"
+export IOS_SDK="18.2"
 export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
 
 rm -rf godot

--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -5,7 +5,7 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no"
-export OPTIONS="osxcross_sdk=darwin23.6 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle"
+export OPTIONS="osxcross_sdk=darwin24.2 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 


### PR DESCRIPTION
Depends on https://github.com/godotengine/build-containers/pull/150.