### PR TITLE
Make multiple export templates tpz files

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -239,6 +239,14 @@ if [ "${build_classical}" == "1" ]; then
   cp out/linux/arm32/templates/godot.linuxbsd.template_release.arm32 ${templatesdir}/linux_release.arm32
   cp out/linux/arm32/templates/godot.linuxbsd.template_debug.arm32 ${templatesdir}/linux_debug.arm32
 
+  zip -q -9 -r -D "${reldir}/${godot_basename}_linux_export_templates.tpz" ${templatesdir}/linux_*
+  for arch in x86_64 x86_32 arm64 arm32; do
+    zip -q -9 -r -D "${reldir}/${godot_basename}_linux_${arch}_export_templates.tpz" ${templatesdir}/linux_*.${arch}
+  done
+  for build in debug release; do
+    zip -q -9 -r -D "${reldir}/${godot_basename}_linux_${build}_export_templates.tpz" ${templatesdir}/linux_${build}.*
+  done
+
   ## Windows (Classical) ##
 
   # Editor
@@ -283,6 +291,14 @@ if [ "${build_classical}" == "1" ]; then
   cp out/windows/arm64/templates/godot.windows.template_release.arm64.llvm.console.exe ${templatesdir}/windows_release_arm64_console.exe
   cp out/windows/arm64/templates/godot.windows.template_debug.arm64.llvm.console.exe ${templatesdir}/windows_debug_arm64_console.exe
 
+  zip -q -9 -r -D "${reldir}/${godot_basename}_windows_export_templates.tpz" ${templatesdir}/windows_*
+  for arch in x86_64 x86_32 arm64; do
+    zip -q -9 -r -D "${reldir}/${godot_basename}_windows_${arch}_export_templates.tpz" ${templatesdir}/windows_*_${arch}*
+  done
+  for build in debug release; do
+    zip -q -9 -r -D "${reldir}/${godot_basename}_windows_${build}_export_templates.tpz" ${templatesdir}/windows_${build}_*
+  done
+
   ## macOS (Classical) ##
 
   # Editor
@@ -322,6 +338,8 @@ if [ "${build_classical}" == "1" ]; then
     unzip ${reldir}/${godot_basename}_macos.universal -d ${steamdir}/
   fi
 
+  zip -q -9 -r -D "${reldir}/${godot_basename}_macos_export_templates.tpz" ${templatesdir}/macos.zip
+
   ## Web (Classical) ##
 
   # Editor
@@ -343,6 +361,13 @@ if [ "${build_classical}" == "1" ]; then
   cp out/web/templates/godot.web.template_release.wasm32.nothreads.dlink.zip ${templatesdir}/web_dlink_nothreads_release.zip
   cp out/web/templates/godot.web.template_debug.wasm32.nothreads.dlink.zip ${templatesdir}/web_dlink_nothreads_debug.zip
 
+  zip -q -9 -r -D "${reldir}/${godot_basename}_web_export_templates.tpz" ${templatesdir}/web_*
+  for build in debug release; do
+    zip -q -9 -r -D "${reldir}/${godot_basename}_web_${build}_export_templates.tpz" ${templatesdir}/web_*${build}.zip
+  done
+  zip -q -9 -r -D "${reldir}/${godot_basename}_web_dlink_export_templates.tpz" ${templatesdir}/web_dlink*
+  zip -q -9 -r -D "${reldir}/${godot_basename}_web_nothreads_export_templates.tpz" ${templatesdir}/web_*nothreads*
+
   ## Android (Classical) ##
 
   # Lib for direct download
@@ -362,6 +387,12 @@ if [ "${build_classical}" == "1" ]; then
   cp out/android/templates/*.apk ${templatesdir}/
   cp out/android/templates/android_source.zip ${templatesdir}/
 
+  zip -q -9 -r -D "${reldir}/${godot_basename}_android_export_templates.tpz" ${templatesdir}/android_*
+  zip -q -9 -r -D "${reldir}/${godot_basename}_android_source_export_templates.tpz" ${templatesdir}/android_source.zip
+  for build in debug release; do
+    zip -q -9 -r -D "${reldir}/${godot_basename}_android_${build}_export_templates.tpz" ${templatesdir}/android_*${build}*
+  done
+
   ## iOS (Classical) ##
 
   rm -rf ios_xcode
@@ -376,6 +407,8 @@ if [ "${build_classical}" == "1" ]; then
   zip -q -9 -r "${templatesdir}/ios.zip" *
   cd ..
   rm -rf ios_xcode
+
+  zip -q -9 -r -D "${reldir}/${godot_basename}_ios_export_templates.tpz" ${templatesdir}/ios.zip
 
   ## Templates TPZ (Classical) ##
 
@@ -446,6 +479,14 @@ if [ "${build_mono}" == "1" ]; then
   cp out/linux/arm32/templates-mono/godot.linuxbsd.template_debug.arm32.mono ${templatesdir_mono}/linux_debug.arm32
   cp out/linux/arm32/templates-mono/godot.linuxbsd.template_release.arm32.mono ${templatesdir_mono}/linux_release.arm32
 
+  zip -q -9 -r -D "${reldir_mono}/${godot_basename}_linux_mono_export_templates.tpz" ${templatesdir_mono}/linux_*
+  for arch in x86_64 x86_32 arm64 arm32; do
+    zip -q -9 -r -D "${reldir_mono}/${godot_basename}_linux_${arch}_mono_export_templates.tpz" ${templatesdir_mono}/linux_*.${arch}
+  done
+  for build in debug release; do
+    zip -q -9 -r -D "${reldir_mono}/${godot_basename}_linux_${build}_mono_export_templates.tpz" ${templatesdir_mono}/linux_${build}.*
+  done
+
   ## Windows (Mono) ##
 
   # Editor
@@ -496,6 +537,14 @@ if [ "${build_mono}" == "1" ]; then
   cp out/windows/arm64/templates-mono/godot.windows.template_debug.arm64.llvm.mono.console.exe ${templatesdir_mono}/windows_debug_arm64_console.exe
   cp out/windows/arm64/templates-mono/godot.windows.template_release.arm64.llvm.mono.console.exe ${templatesdir_mono}/windows_release_arm64_console.exe
 
+  zip -q -9 -r -D "${reldir_mono}/${godot_basename}_windows_mono_export_templates.tpz" ${templatesdir_mono}/windows_*
+  for arch in x86_64 x86_32 arm64; do
+    zip -q -9 -r -D "${reldir_mono}/${godot_basename}_windows_${arch}_mono_export_templates.tpz" ${templatesdir_mono}/windows_*_${arch}*
+  done
+  for build in debug release; do
+    zip -q -9 -r -D "${reldir_mono}/${godot_basename}_windows_${build}_mono_export_templates.tpz" ${templatesdir_mono}/windows_${build}_*
+  done
+
   ## macOS (Mono) ##
 
   # Editor
@@ -521,6 +570,8 @@ if [ "${build_mono}" == "1" ]; then
   rm -rf macos_template.app
   sign_macos_template ${templatesdir_mono} 1
 
+  zip -q -9 -r -D "${reldir_mono}/${godot_basename}_macos_mono_export_templates.tpz" ${templatesdir_mono}/macos.zip
+
   ## Android (Mono) ##
 
   # Lib for direct download
@@ -529,6 +580,12 @@ if [ "${build_mono}" == "1" ]; then
   # Templates
   cp out/android/templates-mono/*.apk ${templatesdir_mono}/
   cp out/android/templates-mono/android_source.zip ${templatesdir_mono}/
+
+  zip -q -9 -r -D "${reldir_mono}/${godot_basename}_android_mono_export_templates.tpz" ${templatesdir_mono}/android_*
+  zip -q -9 -r -D "${reldir_mono}/${godot_basename}_android_source_mono_export_templates.tpz" ${templatesdir_mono}/android_source.zip
+  for build in debug release; do
+    zip -q -9 -r -D "${reldir_mono}/${godot_basename}_android_${build}_mono_export_templates.tpz" ${templatesdir_mono}/android_*${build}*
+  done
 
   ## iOS (Mono) ##
 
@@ -545,6 +602,8 @@ if [ "${build_mono}" == "1" ]; then
   cd ..
   rm -rf ios_xcode
 
+  zip -q -9 -r -D "${reldir_mono}/${godot_basename}_ios_mono_export_templates.tpz" ${templatesdir_mono}/ios.zip
+
   # No .NET support for those platforms yet.
 
   if false; then
@@ -554,6 +613,11 @@ if [ "${build_mono}" == "1" ]; then
   # Templates
   cp out/web/templates-mono/godot.web.template_debug.wasm32.mono.zip ${templatesdir_mono}/web_debug.zip
   cp out/web/templates-mono/godot.web.template_release.wasm32.mono.zip ${templatesdir_mono}/web_release.zip
+
+  zip -q -9 -r -D "${reldir}/${reldir_mono}_web_mono_export_templates.tpz" ${templatesdir_mono}/web_*
+  for build in debug release; do
+    zip -q -9 -r -D "${reldir}/${reldir_mono}_web_${build}_mono_export_templates.tpz" ${templatesdir_mono}/web_*${build}.zip
+  done
 
   fi
 


### PR DESCRIPTION
Partially implements godotengine/godot-proposals#647

Besides the original all-in-one export templates tpz file, `build-release.sh` generates several export templates tpz files to allow smaller downloads.

I arbitrarily decided on which new export templates tpz files create and it's contents. Please fell free to suggest more or less files.

Here is the contents of each new file (used files from Godot 4.4 to test my changes):

<details>
<summary>Classical</summary>

```shell
$ ls -1 releases/4.4-stable/*_export_templates.tpz | xargs -I% zipinfo %
Archive:  releases/4.4-stable/Godot_v4.4-stable_android_debug_export_templates.tpz
Zip file size: 122291622 bytes, number of entries: 1
-rw-r--r--  3.0 unx 123791666 bx defX 25-Mar-06 23:04 Users/pfuente/Repos/godot-build-scripts/tmp/templates/android_debug.apk
1 file, 123791666 bytes uncompressed, 122291330 bytes compressed:  1.2%
Archive:  releases/4.4-stable/Godot_v4.4-stable_android_export_templates.tpz
Zip file size: 434538216 bytes, number of entries: 3
-rw-r--r--  3.0 unx 123791666 bx defX 25-Mar-06 23:04 Users/pfuente/Repos/godot-build-scripts/tmp/templates/android_debug.apk
-rw-r--r--  3.0 unx 104251921 bx defX 25-Mar-06 23:04 Users/pfuente/Repos/godot-build-scripts/tmp/templates/android_release.apk
-rw-r--r--  3.0 unx 208891591 bx defX 25-Mar-06 23:04 Users/pfuente/Repos/godot-build-scripts/tmp/templates/android_source.zip
3 files, 436935178 bytes uncompressed, 434537378 bytes compressed:  0.5%
Archive:  releases/4.4-stable/Godot_v4.4-stable_android_release_export_templates.tpz
Zip file size: 103344819 bytes, number of entries: 1
-rw-r--r--  3.0 unx 104251921 bx defX 25-Mar-06 23:04 Users/pfuente/Repos/godot-build-scripts/tmp/templates/android_release.apk
1 file, 104251921 bytes uncompressed, 103344523 bytes compressed:  0.9%
Archive:  releases/4.4-stable/Godot_v4.4-stable_android_source_export_templates.tpz
Zip file size: 208901819 bytes, number of entries: 1
-rw-r--r--  3.0 unx 208891591 bx defX 25-Mar-06 23:04 Users/pfuente/Repos/godot-build-scripts/tmp/templates/android_source.zip
1 file, 208891591 bytes uncompressed, 208901525 bytes compressed:  0.0%
Archive:  releases/4.4-stable/Godot_v4.4-stable_export_templates.tpz
Zip file size: 1202065022 bytes, number of entries: 34
-rw-r--r--  3.0 unx 123791666 bx defX 25-Mar-06 23:04 templates/android_debug.apk
-rw-r--r--  3.0 unx 104251921 bx defX 25-Mar-06 23:04 templates/android_release.apk
-rw-r--r--  3.0 unx 208891591 bx defX 25-Mar-06 23:04 templates/android_source.zip
-rw-r--r--  3.0 unx 179591877 bx defX 25-Mar-06 23:06 templates/ios.zip
-rwxr-xr-x  3.0 unx 63165984 bx defX 25-Mar-06 22:58 templates/linux_debug.arm32
-rwxr-xr-x  3.0 unx 64005824 bx defX 25-Mar-06 22:58 templates/linux_debug.arm64
-rwxr-xr-x  3.0 unx 73376068 bx defX 25-Mar-06 22:58 templates/linux_debug.x86_32
-rwxr-xr-x  3.0 unx 69962648 bx defX 25-Mar-06 22:58 templates/linux_debug.x86_64
-rwxr-xr-x  3.0 unx 62383592 bx defX 25-Mar-06 22:58 templates/linux_release.arm32
-rwxr-xr-x  3.0 unx 62727784 bx defX 25-Mar-06 22:58 templates/linux_release.arm64
-rwxr-xr-x  3.0 unx 73273700 bx defX 25-Mar-06 22:58 templates/linux_release.x86_32
-rwxr-xr-x  3.0 unx 69659512 bx defX 25-Mar-06 22:58 templates/linux_release.x86_64
-rw-r--r--  3.0 unx 115759872 bx defX 25-Mar-06 23:03 templates/macos.zip
-rw-r--r--  3.0 unx       11 tx stor 25-Mar-06 23:06 templates/version.txt
-rw-r--r--  3.0 unx 10701174 bx defX 25-Mar-06 23:03 templates/web_debug.zip
-rw-r--r--  3.0 unx 12109727 bx defX 25-Mar-06 23:03 templates/web_dlink_debug.zip
-rw-r--r--  3.0 unx 12275349 bx defX 25-Mar-06 23:03 templates/web_dlink_nothreads_debug.zip
-rw-r--r--  3.0 unx 11160109 bx defX 25-Mar-06 23:03 templates/web_dlink_nothreads_release.zip
-rw-r--r--  3.0 unx 11073194 bx defX 25-Mar-06 23:03 templates/web_dlink_release.zip
-rw-r--r--  3.0 unx 10820494 bx defX 25-Mar-06 23:03 templates/web_nothreads_debug.zip
-rw-r--r--  3.0 unx  9581577 bx defX 25-Mar-06 23:03 templates/web_nothreads_release.zip
-rw-r--r--  3.0 unx  9509315 bx defX 25-Mar-06 23:03 templates/web_release.zip
-rwxr-xr-x  3.0 unx 101045248 bx defX 25-Mar-06 23:00 templates/windows_debug_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:00 templates/windows_debug_arm64_console.exe
-rwxr-xr-x  3.0 unx 108975104 bx defX 25-Mar-06 23:00 templates/windows_debug_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:00 templates/windows_debug_x86_32_console.exe
-rwxr-xr-x  3.0 unx 95145472 bx defX 25-Mar-06 23:00 templates/windows_debug_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:00 templates/windows_debug_x86_64_console.exe
-rwxr-xr-x  3.0 unx 92776960 bx defX 25-Mar-06 23:00 templates/windows_release_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:00 templates/windows_release_arm64_console.exe
-rwxr-xr-x  3.0 unx 111142400 bx defX 25-Mar-06 23:00 templates/windows_release_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:00 templates/windows_release_x86_32_console.exe
-rwxr-xr-x  3.0 unx 97496576 bx defX 25-Mar-06 23:00 templates/windows_release_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:00 templates/windows_release_x86_64_console.exe
34 files, 1965737117 bytes uncompressed, 1202058470 bytes compressed:  38.8%
Archive:  releases/4.4-stable/Godot_v4.4-stable_ios_export_templates.tpz
Zip file size: 176814930 bytes, number of entries: 1
-rw-r--r--  3.0 unx 179591877 bx defX 25-Mar-06 23:06 Users/pfuente/Repos/godot-build-scripts/tmp/templates/ios.zip
1 file, 179591877 bytes uncompressed, 176814658 bytes compressed:  1.5%
Archive:  releases/4.4-stable/Godot_v4.4-stable_linux_arm32_export_templates.tpz
Zip file size: 46627839 bytes, number of entries: 2
-rwxr-xr-x  3.0 unx 63165984 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.arm32
-rwxr-xr-x  3.0 unx 62383592 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.arm32
2 files, 125549576 bytes uncompressed, 46627273 bytes compressed:  62.9%
Archive:  releases/4.4-stable/Godot_v4.4-stable_linux_arm64_export_templates.tpz
Zip file size: 49093218 bytes, number of entries: 2
-rwxr-xr-x  3.0 unx 64005824 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.arm64
-rwxr-xr-x  3.0 unx 62727784 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.arm64
2 files, 126733608 bytes uncompressed, 49092652 bytes compressed:  61.3%
Archive:  releases/4.4-stable/Godot_v4.4-stable_linux_debug_export_templates.tpz
Zip file size: 97379363 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 63165984 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.arm32
-rwxr-xr-x  3.0 unx 64005824 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.arm64
-rwxr-xr-x  3.0 unx 73376068 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.x86_32
-rwxr-xr-x  3.0 unx 69962648 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.x86_64
4 files, 270510524 bytes uncompressed, 97378257 bytes compressed:  64.0%
Archive:  releases/4.4-stable/Godot_v4.4-stable_linux_export_templates.tpz
Zip file size: 197708510 bytes, number of entries: 8
-rwxr-xr-x  3.0 unx 63165984 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.arm32
-rwxr-xr-x  3.0 unx 64005824 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.arm64
-rwxr-xr-x  3.0 unx 73376068 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.x86_32
-rwxr-xr-x  3.0 unx 69962648 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.x86_64
-rwxr-xr-x  3.0 unx 62383592 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.arm32
-rwxr-xr-x  3.0 unx 62727784 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.arm64
-rwxr-xr-x  3.0 unx 73273700 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.x86_32
-rwxr-xr-x  3.0 unx 69659512 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.x86_64
8 files, 538555112 bytes uncompressed, 197706304 bytes compressed:  63.3%
Archive:  releases/4.4-stable/Godot_v4.4-stable_linux_release_export_templates.tpz
Zip file size: 100329169 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 62383592 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.arm32
-rwxr-xr-x  3.0 unx 62727784 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.arm64
-rwxr-xr-x  3.0 unx 73273700 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.x86_32
-rwxr-xr-x  3.0 unx 69659512 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.x86_64
4 files, 268044588 bytes uncompressed, 100328047 bytes compressed:  62.6%
Archive:  releases/4.4-stable/Godot_v4.4-stable_linux_x86_32_export_templates.tpz
Zip file size: 51283920 bytes, number of entries: 2
-rwxr-xr-x  3.0 unx 73376068 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.x86_32
-rwxr-xr-x  3.0 unx 73273700 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.x86_32
2 files, 146649768 bytes uncompressed, 51283350 bytes compressed:  65.0%
Archive:  releases/4.4-stable/Godot_v4.4-stable_linux_x86_64_export_templates.tpz
Zip file size: 50703599 bytes, number of entries: 2
-rwxr-xr-x  3.0 unx 69962648 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_debug.x86_64
-rwxr-xr-x  3.0 unx 69659512 bx defX 25-Mar-06 22:58 Users/pfuente/Repos/godot-build-scripts/tmp/templates/linux_release.x86_64
2 files, 139622160 bytes uncompressed, 50703029 bytes compressed:  63.7%
Archive:  releases/4.4-stable/Godot_v4.4-stable_macos_export_templates.tpz
Zip file size: 115280433 bytes, number of entries: 1
-rw-r--r--  3.0 unx 115759872 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/macos.zip
1 file, 115759872 bytes uncompressed, 115280157 bytes compressed:  0.4%
Archive:  releases/4.4-stable/Godot_v4.4-stable_web_debug_export_templates.tpz
Zip file size: 45548774 bytes, number of entries: 4
-rw-r--r--  3.0 unx 10701174 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_debug.zip
-rw-r--r--  3.0 unx 12109727 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_debug.zip
-rw-r--r--  3.0 unx 12275349 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_nothreads_debug.zip
-rw-r--r--  3.0 unx 10820494 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_nothreads_debug.zip
4 files, 45906744 bytes uncompressed, 45547640 bytes compressed:  0.8%
Archive:  releases/4.4-stable/Godot_v4.4-stable_web_dlink_export_templates.tpz
Zip file size: 46136772 bytes, number of entries: 4
-rw-r--r--  3.0 unx 12109727 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_debug.zip
-rw-r--r--  3.0 unx 12275349 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_nothreads_debug.zip
-rw-r--r--  3.0 unx 11160109 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_nothreads_release.zip
-rw-r--r--  3.0 unx 11073194 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_release.zip
4 files, 46618379 bytes uncompressed, 46135606 bytes compressed:  1.0%
Archive:  releases/4.4-stable/Godot_v4.4-stable_web_export_templates.tpz
Zip file size: 86579215 bytes, number of entries: 8
-rw-r--r--  3.0 unx 10701174 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_debug.zip
-rw-r--r--  3.0 unx 12109727 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_debug.zip
-rw-r--r--  3.0 unx 12275349 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_nothreads_debug.zip
-rw-r--r--  3.0 unx 11160109 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_nothreads_release.zip
-rw-r--r--  3.0 unx 11073194 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_release.zip
-rw-r--r--  3.0 unx 10820494 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_nothreads_debug.zip
-rw-r--r--  3.0 unx  9581577 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_nothreads_release.zip
-rw-r--r--  3.0 unx  9509315 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_release.zip
8 files, 87230939 bytes uncompressed, 86576953 bytes compressed:  0.7%
Archive:  releases/4.4-stable/Godot_v4.4-stable_web_nothreads_export_templates.tpz
Zip file size: 43504384 bytes, number of entries: 4
-rw-r--r--  3.0 unx 12275349 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_nothreads_debug.zip
-rw-r--r--  3.0 unx 11160109 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_nothreads_release.zip
-rw-r--r--  3.0 unx 10820494 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_nothreads_debug.zip
-rw-r--r--  3.0 unx  9581577 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_nothreads_release.zip
4 files, 43837529 bytes uncompressed, 43503202 bytes compressed:  0.8%
Archive:  releases/4.4-stable/Godot_v4.4-stable_web_release_export_templates.tpz
Zip file size: 41030463 bytes, number of entries: 4
-rw-r--r--  3.0 unx 11160109 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_nothreads_release.zip
-rw-r--r--  3.0 unx 11073194 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_dlink_release.zip
-rw-r--r--  3.0 unx  9581577 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_nothreads_release.zip
-rw-r--r--  3.0 unx  9509315 bx defX 25-Mar-06 23:03 Users/pfuente/Repos/godot-build-scripts/tmp/templates/web_release.zip
4 files, 41324195 bytes uncompressed, 41029313 bytes compressed:  0.7%
Archive:  releases/4.4-stable/Godot_v4.4-stable_windows_arm64_export_templates.tpz
Zip file size: 59533496 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 101045248 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_arm64_console.exe
-rwxr-xr-x  3.0 unx 92776960 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_arm64_console.exe
4 files, 194141696 bytes uncompressed, 59532306 bytes compressed:  69.3%
Archive:  releases/4.4-stable/Godot_v4.4-stable_windows_debug_export_templates.tpz
Zip file size: 94053749 bytes, number of entries: 6
-rwxr-xr-x  3.0 unx 101045248 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_arm64_console.exe
-rwxr-xr-x  3.0 unx 108975104 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_32_console.exe
-rwxr-xr-x  3.0 unx 95145472 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_64_console.exe
6 files, 305707008 bytes uncompressed, 94051979 bytes compressed:  69.2%
Archive:  releases/4.4-stable/Godot_v4.4-stable_windows_export_templates.tpz
Zip file size: 191146551 bytes, number of entries: 12
-rwxr-xr-x  3.0 unx 101045248 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_arm64_console.exe
-rwxr-xr-x  3.0 unx 108975104 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_32_console.exe
-rwxr-xr-x  3.0 unx 95145472 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_64_console.exe
-rwxr-xr-x  3.0 unx 92776960 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_arm64_console.exe
-rwxr-xr-x  3.0 unx 111142400 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_32_console.exe
-rwxr-xr-x  3.0 unx 97496576 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_64_console.exe
12 files, 607664128 bytes uncompressed, 191143009 bytes compressed:  68.5%
Archive:  releases/4.4-stable/Godot_v4.4-stable_windows_release_export_templates.tpz
Zip file size: 97092824 bytes, number of entries: 6
-rwxr-xr-x  3.0 unx 92776960 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_arm64_console.exe
-rwxr-xr-x  3.0 unx 111142400 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_32_console.exe
-rwxr-xr-x  3.0 unx 97496576 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_64_console.exe
6 files, 301957120 bytes uncompressed, 97091030 bytes compressed:  67.8%
Archive:  releases/4.4-stable/Godot_v4.4-stable_windows_x86_32_export_templates.tpz
Zip file size: 67206854 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 108975104 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_32_console.exe
-rwxr-xr-x  3.0 unx 111142400 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_32_console.exe
4 files, 220502528 bytes uncompressed, 67205656 bytes compressed:  69.5%
Archive:  releases/4.4-stable/Godot_v4.4-stable_windows_x86_64_export_templates.tpz
Zip file size: 64406245 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 95145472 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_debug_x86_64_console.exe
-rwxr-xr-x  3.0 unx 97496576 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:00 Users/pfuente/Repos/godot-build-scripts/tmp/templates/windows_release_x86_64_console.exe
4 files, 193019904 bytes uncompressed, 64405047 bytes compressed:  66.6%
```
</details>

<details>
<summary>Mono</summary>

```shell
$ ls -1 releases/4.4-stable/mono/*_export_templates.tpz | xargs -I% zipinfo %
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_android_debug_mono_export_templates.tpz
Zip file size: 122691249 bytes, number of entries: 1
-rw-r--r--  3.0 unx 124203450 bx defX 25-Mar-06 23:13 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/android_debug.apk
1 file, 124203450 bytes uncompressed, 122690947 bytes compressed:  1.2%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_android_mono_export_templates.tpz
Zip file size: 435907990 bytes, number of entries: 3
-rw-r--r--  3.0 unx 124203450 bx defX 25-Mar-06 23:13 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/android_debug.apk
-rw-r--r--  3.0 unx 104587129 bx defX 25-Mar-06 23:13 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/android_release.apk
-rw-r--r--  3.0 unx 209551015 bx defX 25-Mar-06 23:13 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/android_source.zip
3 files, 438341594 bytes uncompressed, 435907122 bytes compressed:  0.6%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_android_release_mono_export_templates.tpz
Zip file size: 103655902 bytes, number of entries: 1
-rw-r--r--  3.0 unx 104587129 bx defX 25-Mar-06 23:13 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/android_release.apk
1 file, 104587129 bytes uncompressed, 103655596 bytes compressed:  0.9%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_android_source_mono_export_templates.tpz
Zip file size: 209560883 bytes, number of entries: 1
-rw-r--r--  3.0 unx 209551015 bx defX 25-Mar-06 23:13 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/android_source.zip
1 file, 209551015 bytes uncompressed, 209560579 bytes compressed:  0.0%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_ios_mono_export_templates.tpz
Zip file size: 177488536 bytes, number of entries: 1
-rw-r--r--  3.0 unx 180246809 bx defX 25-Mar-06 23:15 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/ios.zip
1 file, 180246809 bytes uncompressed, 177488254 bytes compressed:  1.5%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_linux_arm32_mono_export_templates.tpz
Zip file size: 46758733 bytes, number of entries: 2
-rwxr-xr-x  3.0 unx 63294296 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.arm32
-rwxr-xr-x  3.0 unx 62507800 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.arm32
2 files, 125802096 bytes uncompressed, 46758147 bytes compressed:  62.8%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_linux_arm64_mono_export_templates.tpz
Zip file size: 49256396 bytes, number of entries: 2
-rwxr-xr-x  3.0 unx 64172336 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.arm64
-rwxr-xr-x  3.0 unx 62877896 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.arm64
2 files, 127050232 bytes uncompressed, 49255810 bytes compressed:  61.2%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_linux_debug_mono_export_templates.tpz
Zip file size: 97665983 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 63294296 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.arm32
-rwxr-xr-x  3.0 unx 64172336 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.arm64
-rwxr-xr-x  3.0 unx 73565860 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.x86_32
-rwxr-xr-x  3.0 unx 70149624 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.x86_64
4 files, 271182116 bytes uncompressed, 97664837 bytes compressed:  64.0%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_linux_mono_export_templates.tpz
Zip file size: 198308274 bytes, number of entries: 8
-rwxr-xr-x  3.0 unx 63294296 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.arm32
-rwxr-xr-x  3.0 unx 64172336 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.arm64
-rwxr-xr-x  3.0 unx 73565860 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.x86_32
-rwxr-xr-x  3.0 unx 70149624 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.x86_64
-rwxr-xr-x  3.0 unx 62507800 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.arm32
-rwxr-xr-x  3.0 unx 62877896 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.arm64
-rwxr-xr-x  3.0 unx 73447108 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.x86_32
-rwxr-xr-x  3.0 unx 69830104 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.x86_64
8 files, 539845024 bytes uncompressed, 198305988 bytes compressed:  63.3%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_linux_release_mono_export_templates.tpz
Zip file size: 100642313 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 62507800 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.arm32
-rwxr-xr-x  3.0 unx 62877896 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.arm64
-rwxr-xr-x  3.0 unx 73447108 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.x86_32
-rwxr-xr-x  3.0 unx 69830104 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.x86_64
4 files, 268662908 bytes uncompressed, 100641151 bytes compressed:  62.5%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_linux_x86_32_mono_export_templates.tpz
Zip file size: 51457149 bytes, number of entries: 2
-rwxr-xr-x  3.0 unx 73565860 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.x86_32
-rwxr-xr-x  3.0 unx 73447108 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.x86_32
2 files, 147012968 bytes uncompressed, 51456559 bytes compressed:  65.0%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_linux_x86_64_mono_export_templates.tpz
Zip file size: 50836062 bytes, number of entries: 2
-rwxr-xr-x  3.0 unx 70149624 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_debug.x86_64
-rwxr-xr-x  3.0 unx 69830104 bx defX 25-Mar-06 23:08 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/linux_release.x86_64
2 files, 139979728 bytes uncompressed, 50835472 bytes compressed:  63.7%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_macos_mono_export_templates.tpz
Zip file size: 115623738 bytes, number of entries: 1
-rw-r--r--  3.0 unx 116111052 bx defX 25-Mar-06 23:13 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/macos.zip
1 file, 116111052 bytes uncompressed, 115623452 bytes compressed:  0.4%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_mono_export_templates.tpz
Zip file size: 1119093362 bytes, number of entries: 26
-rw-r--r--  3.0 unx 124203450 bx defX 25-Mar-06 23:13 templates/android_debug.apk
-rw-r--r--  3.0 unx 104587129 bx defX 25-Mar-06 23:13 templates/android_release.apk
-rw-r--r--  3.0 unx 209551015 bx defX 25-Mar-06 23:13 templates/android_source.zip
-rw-r--r--  3.0 unx 180246809 bx defX 25-Mar-06 23:15 templates/ios.zip
-rwxr-xr-x  3.0 unx 63294296 bx defX 25-Mar-06 23:08 templates/linux_debug.arm32
-rwxr-xr-x  3.0 unx 64172336 bx defX 25-Mar-06 23:08 templates/linux_debug.arm64
-rwxr-xr-x  3.0 unx 73565860 bx defX 25-Mar-06 23:08 templates/linux_debug.x86_32
-rwxr-xr-x  3.0 unx 70149624 bx defX 25-Mar-06 23:08 templates/linux_debug.x86_64
-rwxr-xr-x  3.0 unx 62507800 bx defX 25-Mar-06 23:08 templates/linux_release.arm32
-rwxr-xr-x  3.0 unx 62877896 bx defX 25-Mar-06 23:08 templates/linux_release.arm64
-rwxr-xr-x  3.0 unx 73447108 bx defX 25-Mar-06 23:08 templates/linux_release.x86_32
-rwxr-xr-x  3.0 unx 69830104 bx defX 25-Mar-06 23:08 templates/linux_release.x86_64
-rw-r--r--  3.0 unx 116111052 bx defX 25-Mar-06 23:13 templates/macos.zip
-rw-r--r--  3.0 unx       16 tx stor 25-Mar-06 23:15 templates/version.txt
-rwxr-xr-x  3.0 unx 101349376 bx defX 25-Mar-06 23:10 templates/windows_debug_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:10 templates/windows_debug_arm64_console.exe
-rwxr-xr-x  3.0 unx 109297664 bx defX 25-Mar-06 23:10 templates/windows_debug_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:10 templates/windows_debug_x86_32_console.exe
-rwxr-xr-x  3.0 unx 95408640 bx defX 25-Mar-06 23:10 templates/windows_debug_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:10 templates/windows_debug_x86_64_console.exe
-rwxr-xr-x  3.0 unx 93047808 bx defX 25-Mar-06 23:10 templates/windows_release_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:10 templates/windows_release_arm64_console.exe
-rwxr-xr-x  3.0 unx 111449088 bx defX 25-Mar-06 23:10 templates/windows_release_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:10 templates/windows_release_x86_32_console.exe
-rwxr-xr-x  3.0 unx 97742336 bx defX 25-Mar-06 23:10 templates/windows_release_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:10 templates/windows_release_x86_64_console.exe
26 files, 1883921775 bytes uncompressed, 1119088346 bytes compressed:  40.6%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_windows_arm64_mono_export_templates.tpz
Zip file size: 59736364 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 101349376 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_arm64_console.exe
-rwxr-xr-x  3.0 unx 93047808 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_arm64_console.exe
4 files, 194716672 bytes uncompressed, 59735134 bytes compressed:  69.3%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_windows_debug_mono_export_templates.tpz
Zip file size: 94375093 bytes, number of entries: 6
-rwxr-xr-x  3.0 unx 101349376 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_arm64_console.exe
-rwxr-xr-x  3.0 unx 109297664 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_32_console.exe
-rwxr-xr-x  3.0 unx 95408640 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_64_console.exe
6 files, 306596864 bytes uncompressed, 94373263 bytes compressed:  69.2%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_windows_mono_export_templates.tpz
Zip file size: 191767176 bytes, number of entries: 12
-rwxr-xr-x  3.0 unx 101349376 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_arm64_console.exe
-rwxr-xr-x  3.0 unx 109297664 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_32_console.exe
-rwxr-xr-x  3.0 unx 95408640 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_64_console.exe
-rwxr-xr-x  3.0 unx 93047808 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_arm64_console.exe
-rwxr-xr-x  3.0 unx 111449088 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_32_console.exe
-rwxr-xr-x  3.0 unx 97742336 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_64_console.exe
12 files, 609377280 bytes uncompressed, 191763514 bytes compressed:  68.5%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_windows_release_mono_export_templates.tpz
Zip file size: 97392105 bytes, number of entries: 6
-rwxr-xr-x  3.0 unx 93047808 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_arm64.exe
-rwxr-xr-x  3.0 unx   159744 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_arm64_console.exe
-rwxr-xr-x  3.0 unx 111449088 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_32_console.exe
-rwxr-xr-x  3.0 unx 97742336 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_64_console.exe
6 files, 302780416 bytes uncompressed, 97390251 bytes compressed:  67.8%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_windows_x86_32_mono_export_templates.tpz
Zip file size: 67424485 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 109297664 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_32_console.exe
-rwxr-xr-x  3.0 unx 111449088 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_32.exe
-rwxr-xr-x  3.0 unx   192512 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_32_console.exe
4 files, 221131776 bytes uncompressed, 67423247 bytes compressed:  69.5%
Archive:  releases/4.4-stable/mono/Godot_v4.4-stable_windows_x86_64_mono_export_templates.tpz
Zip file size: 64606371 bytes, number of entries: 4
-rwxr-xr-x  3.0 unx 95408640 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_debug_x86_64_console.exe
-rwxr-xr-x  3.0 unx 97742336 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_64.exe
-rwxr-xr-x  3.0 unx   188928 bx defX 25-Mar-06 23:10 Users/pfuente/Repos/godot-build-scripts/tmp/mono/templates/windows_release_x86_64_console.exe
4 files, 193528832 bytes uncompressed, 64605133 bytes compressed:  66.6%
```
</details>