### PR TITLE
Update the Android build scripts to allow exporting 'Godot Tools' Android library to MavenCentral

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -60,11 +60,7 @@ if [ "${CLASSICAL}" == "1" ]; then
     cp bin/android_editor_builds/android_editor-picoos-debug.apk /root/out/tools/android_editor_picoos.apk
   fi
 
-  # Restart from a clean tarball, as we'll copy all the contents
-  # outside the container for the MavenCentral upload.
-  rm -rf /root/godot/*
-  tar xf /root/godot.tar.gz --strip-components=1
-  cp -rf /root/swappy/* thirdparty/swappy-frame-pacing/
+  # Template builds
 
   $SCONS platform=android arch=arm32 $OPTIONS target=template_debug
   $SCONS platform=android arch=arm32 $OPTIONS target=template_release

--- a/build-android/upload-mavencentral.sh
+++ b/build-android/upload-mavencentral.sh
@@ -15,4 +15,4 @@ ${PODMAN} run -it --rm \
     "source /root/keystore/config.sh && \
     cp -r /root/godot/.gradle /root && \
     cd /root/godot/platform/android/java && \
-    ./gradlew publishTemplateReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository"
+    ./gradlew publishAllPublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository"


### PR DESCRIPTION
Build scripts counterpart to https://github.com/godotengine/godot/pull/104819; this PR updates the build scripts so that the content generated for the `editor` build are preserved when copying out the `godot` directory.
The `mavencentral` publish command has been updated to publish all publications in the project.