### PR TITLE
Update access-kit to 0.16.0, reenable it for 32-bit Windows builds.

### DIFF
--- a/build-windows/build.sh
+++ b/build-windows/build.sh
@@ -8,8 +8,6 @@ export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_
 export OPTIONS="production=yes use_mingw=yes angle_libs=/root/angle mesa_libs=/root/mesa d3d12=yes accesskit_sdk_path=/root/accesskit/accesskit-c"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_LLVM="use_llvm=yes mingw_prefix=/root/llvm-mingw"
-# Doesn't work currently for x86_32 with our mingw setup.
-export OPTIONS_X86_32="accesskit=no"
 export TERM=xterm
 
 rm -rf godot
@@ -33,13 +31,13 @@ if [ "${CLASSICAL}" == "1" ]; then
   cp -rvp bin/* /root/out/x86_64/templates
   rm -rf bin
 
-  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_X86_32 target=editor
+  $SCONS platform=windows arch=x86_32 $OPTIONS target=editor
   mkdir -p /root/out/x86_32/tools
   cp -rvp bin/* /root/out/x86_32/tools
   rm -rf bin
 
-  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_X86_32 target=template_debug
-  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_X86_32 target=template_release
+  $SCONS platform=windows arch=x86_32 $OPTIONS target=template_debug
+  $SCONS platform=windows arch=x86_32 $OPTIONS target=template_release
   mkdir -p /root/out/x86_32/templates
   cp -rvp bin/* /root/out/x86_32/templates
   rm -rf bin
@@ -59,7 +57,7 @@ if [ "${CLASSICAL}" == "1" ]; then
     build_name=${BUILD_NAME}
     export BUILD_NAME="steam"
     $SCONS platform=windows arch=x86_64 $OPTIONS target=editor steamapi=yes
-    $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_X86_32 target=editor steamapi=yes
+    $SCONS platform=windows arch=x86_32 $OPTIONS target=editor steamapi=yes
     mkdir -p /root/out/steam
     cp -rvp bin/* /root/out/steam
     rm -rf bin
@@ -87,14 +85,14 @@ if [ "${MONO}" == "1" ]; then
   cp -rvp bin/* /root/out/x86_64/templates-mono
   rm -rf bin
 
-  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO $OPTIONS_X86_32 target=editor
+  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO target=editor
   ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows
   mkdir -p /root/out/x86_32/tools-mono
   cp -rvp bin/* /root/out/x86_32/tools-mono
   rm -rf bin
 
-  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO $OPTIONS_X86_32 target=template_debug
-  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO $OPTIONS_X86_32 target=template_release
+  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO target=template_debug
+  $SCONS platform=windows arch=x86_32 $OPTIONS $OPTIONS_MONO target=template_release
   mkdir -p /root/out/x86_32/templates-mono
   cp -rvp bin/* /root/out/x86_32/templates-mono
   rm -rf bin

--- a/build.sh
+++ b/build.sh
@@ -161,7 +161,7 @@ if [ ! -d "deps/accesskit" ]; then
   echo "Missing accesskit, downloading it."
   mkdir -p deps/accesskit
   pushd deps/accesskit
-  curl -L -o accesskit.zip https://github.com/godotengine/godot-accesskit-c-static/releases/download/0.15.1/accesskit-c-0.15.1.zip
+  curl -L -o accesskit.zip https://github.com/godotengine/godot-accesskit-c-static/releases/download/0.16.0/accesskit-c-0.16.0.zip
   unzip -o accesskit.zip && rm -f accesskit.zip
   mv accesskit-c-* accesskit-c
   popd


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot/pull/106659

32-bit builds crash was fixed (https://github.com/AccessKit/accesskit-c/issues/36)