### PR TITLE
Apple: add visionOS build support; unify build container

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -12,7 +12,10 @@ export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
 export IOS_SDK="18.5"
-export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
+export IOS_DEVICE="IOS_SDK_PATH=/root/SDKs/iPhoneOS${IOS_SDK}.sdk"
+export IOS_SIMULATOR="IOS_SDK_PATH=/root/SDKs/iPhoneSimulator${IOS_SDK}.sdk simulator=yes"
+export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"
+export APPLE_TARGET_X86_64="APPLE_TOOLCHAIN_PATH=/root/ioscross/x86_64 apple_target_triple=x86_64-apple-darwin11-"
 
 rm -rf godot
 mkdir godot
@@ -25,30 +28,22 @@ if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for iOS..."
 
   # arm64 device
-  $SCONS platform=ios $OPTIONS arch=arm64 ios_simulator=no target=template_debug \
-    IOS_SDK_PATH="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
-  $SCONS platform=ios $OPTIONS arch=arm64 ios_simulator=no target=template_release \
-    IOS_SDK_PATH="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
+  $SCONS platform=ios $OPTIONS arch=arm64 target=template_debug $IOS_DEVICE $APPLE_TARGET_ARM64
+  $SCONS platform=ios $OPTIONS arch=arm64 target=template_release $IOS_DEVICE $APPLE_TARGET_ARM64
 
   # arm64 simulator
   # Disabled for now as it doesn't work with cctools-port and current LLVM.
   # See https://github.com/godotengine/build-containers/pull/85.
-  #$SCONS platform=ios $OPTIONS arch=arm64 ios_simulator=yes target=template_debug \
-  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
-  #$SCONS platform=ios $OPTIONS arch=arm64 ios_simulator=yes target=template_release \
-  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #$SCONS platform=ios $OPTIONS arch=arm64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_ARM64
+  #$SCONS platform=ios $OPTIONS arch=arm64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_ARM64
 
   # x86_64 simulator
-  $SCONS platform=ios $OPTIONS arch=x86_64 ios_simulator=yes target=template_debug \
-    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
-  $SCONS platform=ios $OPTIONS arch=x86_64 ios_simulator=yes target=template_release \
-    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+  $SCONS platform=ios $OPTIONS arch=x86_64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_X86_64
+  $SCONS platform=ios $OPTIONS arch=x86_64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_X86_64
 
   mkdir -p /root/out/templates
   cp bin/libgodot.ios.template_release.arm64.a /root/out/templates/libgodot.ios.a
   cp bin/libgodot.ios.template_debug.arm64.a /root/out/templates/libgodot.ios.debug.a
-  #$IOS_LIPO -create bin/libgodot.ios.template_release.arm64.simulator.a bin/libgodot.ios.template_release.x86_64.simulator.a -output /root/out/templates/libgodot.ios.simulator.a
-  #$IOS_LIPO -create bin/libgodot.ios.template_debug.arm64.simulator.a bin/libgodot.ios.template_debug.x86_64.simulator.a -output /root/out/templates/libgodot.ios.debug.simulator.a
   cp bin/libgodot.ios.template_release.x86_64.simulator.a /root/out/templates/libgodot.ios.simulator.a
   cp bin/libgodot.ios.template_debug.x86_64.simulator.a /root/out/templates/libgodot.ios.debug.simulator.a
 fi
@@ -61,31 +56,22 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
 
   # arm64 device
-  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=no target=template_debug \
-    IOS_SDK_PATH="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
-  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=no target=template_release \
-    IOS_SDK_PATH="/root/ioscross/arm64/SDK/iPhoneOS${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/arm64/" ios_triple="arm-apple-darwin11-"
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug $IOS_DEVICE $APPLE_TARGET_ARM64
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $IOS_DEVICE $APPLE_TARGET_ARM64
 
   # arm64 simulator
   # Disabled for now as it doesn't work with cctools-port and current LLVM.
   # See https://github.com/godotengine/build-containers/pull/85.
-  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes target=template_debug \
-  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
-  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 ios_simulator=yes target=template_release \
-  #  IOS_SDK_PATH="/root/ioscross/arm64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/arm64_sim/" ios_triple="arm-apple-darwin11-"
+  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_ARM64
+  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_ARM64
 
   # x86_64 simulator
-  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes target=template_debug \
-    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
-  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 ios_simulator=yes target=template_release \
-    IOS_SDK_PATH="/root/ioscross/x86_64_sim/SDK/iPhoneSimulator${IOS_SDK}.sdk" APPLE_TOOLCHAIN_PATH="/root/ioscross/x86_64_sim/" ios_triple="x86_64-apple-darwin11-"
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_X86_64
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_X86_64
 
   mkdir -p /root/out/templates-mono
-
   cp bin/libgodot.ios.template_release.arm64.a /root/out/templates-mono/libgodot.ios.a
   cp bin/libgodot.ios.template_debug.arm64.a /root/out/templates-mono/libgodot.ios.debug.a
-  #$IOS_LIPO -create bin/libgodot.ios.template_release.arm64.simulator.a bin/libgodot.ios.template_release.x86_64.simulator.a -output /root/out/templates-mono/libgodot.ios.simulator.a
-  #$IOS_LIPO -create bin/libgodot.ios.template_debug.arm64.simulator.a bin/libgodot.ios.template_debug.x86_64.simulator.a -output /root/out/templates-mono/libgodot.ios.debug.simulator.a
   cp bin/libgodot.ios.template_release.x86_64.simulator.a /root/out/templates-mono/libgodot.ios.simulator.a
   cp bin/libgodot.ios.template_debug.x86_64.simulator.a /root/out/templates-mono/libgodot.ios.debug.simulator.a
 fi

--- a/build-release.sh
+++ b/build-release.sh
@@ -377,6 +377,17 @@ if [ "${build_classical}" == "1" ]; then
   cd ..
   rm -rf ios_xcode
 
+  ## visionOS (Classical) ##
+
+  rm -rf visionos_xcode
+  cp -r git/misc/dist/visionos_xcode visionos_xcode
+  cp out/visionos/templates/libgodot.visionos.a visionos_xcode/libgodot.visionos.release.xcframework/xros-arm64/libgodot.a
+  cp out/visionos/templates/libgodot.visionos.debug.a visionos_xcode/libgodot.visionos.debug.xcframework/xros-arm64/libgodot.a
+  cd visionos_xcode
+  zip -q -9 -r "${templatesdir}/visionos.zip" *
+  cd ..
+  rm -rf visionos_xcode
+
   ## Templates TPZ (Classical) ##
 
   echo "${templates_version}" > ${templatesdir}/version.txt
@@ -544,6 +555,17 @@ if [ "${build_mono}" == "1" ]; then
   zip -q -9 -r "${templatesdir_mono}/ios.zip" *
   cd ..
   rm -rf ios_xcode
+
+  ## visionOS (Mono) ##
+
+  rm -rf visionos_xcode
+  cp -r git/misc/dist/visionos_xcode visionos_xcode
+  cp out/visionos/templates-mono/libgodot.visionos.a visionos_xcode/libgodot.visionos.release.xcframework/xros-arm64/libgodot.a
+  cp out/visionos/templates-mono/libgodot.visionos.debug.a visionos_xcode/libgodot.visionos.debug.xcframework/xros-arm64/libgodot.a
+  cd visionos_xcode
+  zip -q -9 -r "${templatesdir_mono}/visionos.zip" *
+  cd ..
+  rm -rf visionos_xcode
 
   # No .NET support for those platforms yet.
 

--- a/build-visionos/build.sh
+++ b/build-visionos/build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+# Config
+
+export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
+# Keep LTO disabled for visionOS - it works but it makes linking apps on deploy very slow,
+# which is seen as a regression in the current workflow.
+# Disable Vulkan and MoltenVK for visionOS - visionOS doesn't support MoltenVK.
+export OPTIONS="production=yes use_lto=no vulkan=no"
+export OPTIONS_MONO="module_mono_enabled=yes"
+export TERM=xterm
+
+export VISIONOS_SDK="2.5"
+export VISIONOS_DEVICE="VISIONOS_SDK_PATH=/root/SDKs/XROS${VISIONOS_SDK}.sdk"
+export VISIONOS_SIMULATOR="VISIONOS_SDK_PATH=/root/SDKs/XRSimulator${VISIONOS_SDK}.sdk simulator=yes"
+export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"
+
+rm -rf godot
+mkdir godot
+cd godot
+tar xf /root/godot.tar.gz --strip-components=1
+
+# Classical
+
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for visionOS..."
+
+  # arm64 device
+  $SCONS platform=visionos $OPTIONS arch=arm64 target=template_debug $VISIONOS_DEVICE $APPLE_TARGET_ARM64
+  $SCONS platform=visionos $OPTIONS arch=arm64 target=template_release $VISIONOS_DEVICE $APPLE_TARGET_ARM64
+
+  # arm64 simulator (disabled for now, see build-ios)
+  #$SCONS platform=visionos $OPTIONS arch=arm64 target=template_debug $VISIONOS_SIMULATOR $APPLE_TARGET_ARM64
+  #$SCONS platform=visionos $OPTIONS arch=arm64 target=template_release $VISIONOS_SIMULATOR $APPLE_TARGET_ARM64
+
+  mkdir -p /root/out/templates
+  cp bin/libgodot.visionos.template_release.arm64.a /root/out/templates/libgodot.visionos.a
+  cp bin/libgodot.visionos.template_debug.arm64.a /root/out/templates/libgodot.visionos.debug.a
+fi
+
+# Mono
+
+if [ "${MONO}" == "1" ]; then
+  echo "Starting Mono build for visionOS..."
+
+  cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
+
+  # arm64 device
+  $SCONS platform=visionos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug $VISIONOS_DEVICE $APPLE_TARGET_ARM64
+  $SCONS platform=visionos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $VISIONOS_DEVICE $APPLE_TARGET_ARM64
+
+  # arm64 simulator (disabled for now, see build-ios)
+  #$SCONS platform=visionos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug $VISIONOS_SIMULATOR $APPLE_TARGET_ARM64
+  #$SCONS platform=visionos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $VISIONOS_SIMULATOR $APPLE_TARGET_ARM64
+
+  mkdir -p /root/out/templates-mono
+  cp bin/libgodot.visionos.template_release.arm64.a /root/out/templates-mono/libgodot.visionos.a
+  cp bin/libgodot.visionos.template_debug.arm64.a /root/out/templates-mono/libgodot.visionos.debug.a
+fi
+
+echo "visionOS build successful"

--- a/build.sh
+++ b/build.sh
@@ -133,7 +133,7 @@ if [ $skip_download == 0 ]; then
   if [ ! -z "${logged_in}" ]; then
     echo "Fetching private images"
 
-    for image in macosx android ios; do
+    for image in macosx android appleembedded; do
       if [ ${force_download} == 1 ] || ! ${podman} image exists godot-private/$image; then
         if ! ${podman} pull ${registry}/godot-private/${image}; then
           echo "ERROR: image $image does not exist and can't be downloaded"
@@ -269,7 +269,10 @@ mkdir -p ${basedir}/out/android
 ${podman_run} -v ${basedir}/build-android:/root/build -v ${basedir}/out/android:/root/out -v ${basedir}/deps/swappy:/root/swappy -v ${basedir}/deps/keystore:/root/keystore localhost/godot-android:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/android
 
 mkdir -p ${basedir}/out/ios
-${podman_run} -v ${basedir}/build-ios:/root/build -v ${basedir}/out/ios:/root/out localhost/godot-ios:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/ios
+${podman_run} -v ${basedir}/build-ios:/root/build -v ${basedir}/out/ios:/root/out localhost/godot-appleembedded:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/ios
+
+mkdir -p ${basedir}/out/visionos
+${podman_run} -v ${basedir}/build-visionos:/root/build -v ${basedir}/out/visionos:/root/out localhost/godot-appleembedded:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/visionos
 
 uid=$(id -un)
 gid=$(id -gn)


### PR DESCRIPTION
Depends:

- https://github.com/godotengine/build-containers/pull/154

Adds support for building visionOS and tvOS templates