### PR TITLE
Update toolchains based on Fedora 42 for Godot 4.5

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -11,7 +11,7 @@ export OPTIONS="production=yes use_lto=no"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 
-export IOS_SDK="18.2"
+export IOS_SDK="18.5"
 export IOS_LIPO="/root/ioscross/arm64/bin/arm-apple-darwin11-lipo"
 
 rm -rf godot

--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -5,7 +5,7 @@ set -e
 # Config
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
-export OPTIONS="osxcross_sdk=darwin24.2 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c"
+export OPTIONS="osxcross_sdk=darwin24.5 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export TERM=xterm
 


### PR DESCRIPTION
- Follow up to https://github.com/godotengine/build-containers/pull/151.