### PR TITLE
Android: Fix native debug symbols generation

### DIFF
--- a/build-android/build.sh
+++ b/build-android/build.sh
@@ -4,8 +4,8 @@ set -e
 
 # Config
 
-# Debug symbols are enabled for the Android builds. Gradle will strip them out of
-# the final artifacts and generate a separate debug symbols file.
+# Debug symbols are enabled for the Android builds so we can generate a separate debug symbols file. 
+# Gradle will strip them out of the final artifacts.
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 export OPTIONS="production=yes debug_symbols=yes"
 export OPTIONS_MONO="module_mono_enabled=yes"
@@ -40,7 +40,7 @@ if [ "${CLASSICAL}" == "1" ]; then
   $SCONS platform=android arch=arm32 $OPTIONS target=editor store_release=${store_release}
   $SCONS platform=android arch=arm64 $OPTIONS target=editor store_release=${store_release}
   $SCONS platform=android arch=x86_32 $OPTIONS target=editor store_release=${store_release}
-  $SCONS platform=android arch=x86_64 $OPTIONS target=editor store_release=${store_release}
+  $SCONS platform=android arch=x86_64 $OPTIONS target=editor store_release=${store_release} separate_debug_symbols=yes # Generate native debug symbols.
 
   pushd platform/android/java
   # Generate the regular Android editor.
@@ -53,28 +53,27 @@ if [ "${CLASSICAL}" == "1" ]; then
 
   mkdir -p /root/out/tools
 
-  # Copy the generated Android editor binaries (apk & aab).
   if [ "$store_release" == "yes" ]; then
-    cp bin/android_editor_builds/android-editor-android-release-native-debug-symbols.zip /root/out/tools/android_editor_native_debug_symbols.zip
+    # Copy the native debug symbols, a single one cover all editor builds.
+    cp bin/android-editor-release-native-symbols.zip /root/out/tools/android_editor_native_debug_symbols.zip
+
+    # Copy the generated Android editor binaries (apk & aab).
     cp bin/android_editor_builds/android_editor-android-release.apk /root/out/tools/android_editor.apk
     cp bin/android_editor_builds/android_editor-android-release.aab /root/out/tools/android_editor.aab
 
     # For the HorizonOS and PicoOS builds, we only copy the apk.
-    cp bin/android_editor_builds/android-editor-horizonos-release-native-debug-symbols.zip /root/out/tools/android_editor_horizonos_native_debug_symbols.zip
     cp bin/android_editor_builds/android_editor-horizonos-release.apk /root/out/tools/android_editor_horizonos.apk
-
-    cp bin/android_editor_builds/android-editor-picoos-release-native-debug-symbols.zip /root/out/tools/android_editor_picoos_native_debug_symbols.zip
     cp bin/android_editor_builds/android_editor-picoos-release.apk /root/out/tools/android_editor_picoos.apk
   else
-    cp bin/android_editor_builds/android-editor-android-debug-native-debug-symbols.zip /root/out/tools/android_editor_native_debug_symbols.zip
+    # Copy the native debug symbols, a single one cover all editor builds.
+    cp bin/android-editor-debug-native-symbols.zip /root/out/tools/android_editor_native_debug_symbols.zip
+
+    # Copy the generated Android editor binaries (apk & aab).
     cp bin/android_editor_builds/android_editor-android-debug.apk /root/out/tools/android_editor.apk
     cp bin/android_editor_builds/android_editor-android-debug.aab /root/out/tools/android_editor.aab
 
     # For the HorizonOS and PicoOS build, we only copy the apk.
-    cp bin/android_editor_builds/android-editor-horizonos-debug-native-debug-symbols.zip /root/out/tools/android_editor_horizonos_native_debug_symbols.zip
     cp bin/android_editor_builds/android_editor-horizonos-debug.apk /root/out/tools/android_editor_horizonos.apk
-
-    cp bin/android_editor_builds/android-editor-picoos-debug-native-debug-symbols.zip /root/out/tools/android_editor_picoos_native_debug_symbols.zip
     cp bin/android_editor_builds/android_editor-picoos-debug.apk /root/out/tools/android_editor_picoos.apk
   fi
 
@@ -82,17 +81,15 @@ if [ "${CLASSICAL}" == "1" ]; then
 
   prepare_source
 
-  $SCONS platform=android arch=arm32 $OPTIONS target=template_debug
   $SCONS platform=android arch=arm32 $OPTIONS target=template_release
-
-  $SCONS platform=android arch=arm64 $OPTIONS target=template_debug
   $SCONS platform=android arch=arm64 $OPTIONS target=template_release
-
-  $SCONS platform=android arch=x86_32 $OPTIONS target=template_debug
   $SCONS platform=android arch=x86_32 $OPTIONS target=template_release
+  $SCONS platform=android arch=x86_64 $OPTIONS target=template_release separate_debug_symbols=yes # Generate native debug symbols only for the release templates.
 
+  $SCONS platform=android arch=arm32 $OPTIONS target=template_debug
+  $SCONS platform=android arch=arm64 $OPTIONS target=template_debug
+  $SCONS platform=android arch=x86_32 $OPTIONS target=template_debug
   $SCONS platform=android arch=x86_64 $OPTIONS target=template_debug
-  $SCONS platform=android arch=x86_64 $OPTIONS target=template_release
 
   pushd platform/android/java
   ./gradlew generateGodotTemplates
@@ -111,8 +108,7 @@ if [ "${CLASSICAL}" == "1" ]; then
   cp bin/android_debug.apk /root/out/templates/
   cp bin/android_release.apk /root/out/templates/
   cp bin/godot-lib.template_release.aar /root/out/templates/
-  cp bin/android-template-standard-debug-native-debug-symbols.zip /root/out/templates/android_debug_template_native_debug_symbols.zip
-  cp bin/android-template-standard-release-native-debug-symbols.zip /root/out/templates/android_release_template_native_debug_symbols.zip
+  cp bin/android-template-release-native-symbols.zip /root/out/templates/android_release_template_native_debug_symbols.zip
 fi
 
 # Mono
@@ -145,8 +141,6 @@ if [ "${MONO}" == "1" ]; then
   cp bin/android_monoDebug.apk /root/out/templates-mono/android_debug.apk
   cp bin/android_monoRelease.apk /root/out/templates-mono/android_release.apk
   cp bin/godot-lib.template_release.aar /root/out/templates-mono/
-  cp bin/android-template-mono-debug-native-debug-symbols.zip /root/out/templates-mono/android_debug_template_native_debug_symbols.zip
-  cp bin/android-template-mono-release-native-debug-symbols.zip /root/out/templates-mono/android_release_template_native_debug_symbols.zip
 fi
 
 echo "Android build successful"


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-build-scripts/pull/112, depends on https://github.com/godotengine/godot/pull/107998.

The native debug symbols file generated by `gradle` were invalid and could not be used to symbolicate native crashes. With https://github.com/godotengine/godot/pull/107998, the process has been updated to use the `.so` files generated by `scons` instead.

As a side effect, the `aab` no longer contains the native debug symbols file (although this means the file will need to be manually uploaded to the Play store) and is much smaller: `1.1GB` -> `280MB`