### PR TITLE
Include the Android native debug symbols in the release binaries

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -362,6 +362,10 @@ if [ "${build_classical}" == "1" ]; then
   cp out/android/templates/*.apk ${templatesdir}/
   cp out/android/templates/android_source.zip ${templatesdir}/
 
+  # Native debug symbols
+  cp out/android/templates/android_release_template_native_debug_symbols.zip ${reldir}/native_debug_symbols.${templates_version}.template_release.android.zip
+  cp out/android/tools/android_editor_native_debug_symbols.zip ${reldir}/native_debug_symbols.${templates_version}.editor.android.zip
+
   ## iOS (Classical) ##
 
   rm -rf ios_xcode


### PR DESCRIPTION
First iteration of exposing the generated native debug symbols for use for the Android / XR editor, and to help debug Godot release Android binaries.

We'll iterate on this based on the size of the generated artifacts, and also based on feedback for how we should expose native debug symbols for other platforms.