### PR TITLE
Update the name of the Android native debug symbols files to start with a `g`

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -363,8 +363,8 @@ if [ "${build_classical}" == "1" ]; then
   cp out/android/templates/android_source.zip ${templatesdir}/
 
   # Native debug symbols
-  cp out/android/templates/android_release_template_native_debug_symbols.zip ${reldir}/native_debug_symbols.${templates_version}.template_release.android.zip
-  cp out/android/tools/android_editor_native_debug_symbols.zip ${reldir}/native_debug_symbols.${templates_version}.editor.android.zip
+  cp out/android/templates/android_release_template_native_debug_symbols.zip ${reldir}/Godot_native_debug_symbols.${templates_version}.template_release.android.zip
+  cp out/android/tools/android_editor_native_debug_symbols.zip ${reldir}/Godot_native_debug_symbols.${templates_version}.editor.android.zip
 
   ## iOS (Classical) ##
 


### PR DESCRIPTION
This should address the issue with uploading the Android native debug symbols.

Fixes https://github.com/godotengine/godot-build-scripts/issues/125