### PR TITLE
Apple: visionOS and tvOS builds now supported; update to 26.4 SDKs

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -7,12 +7,12 @@ set -e
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for iOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
-export OPTIONS="production=yes use_lto=no SWIFT_FRONTEND=/root/.local/share/swiftly/toolchains/6.2.1/usr/bin/swift-frontend"
+export OPTIONS="production=yes use_lto=no SWIFT_FRONTEND=/root/.local/share/swiftly/toolchains/6.3.0/usr/bin/swift-frontend"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm
 
-export IOS_SDK="26.1"
+export IOS_SDK="26.4"
 export IOS_DEVICE="IOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS${IOS_SDK}.sdk"
 export IOS_SIMULATOR="IOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator${IOS_SDK}.sdk simulator=yes"
 export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"

--- a/build-tvos/build.sh
+++ b/build-tvos/build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+# Config
+
+export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
+# Keep LTO disabled for tvOS - it works but it makes linking apps on deploy very slow,
+# which is seen as a regression in the current workflow (mirrors the iOS build).
+export OPTIONS="production=yes use_lto=no vulkan=no opengl3=no SWIFT_FRONTEND=/root/.local/share/swiftly/toolchains/6.3.0/usr/bin/swift-frontend"
+export OPTIONS_MONO="module_mono_enabled=yes"
+export OPTIONS_DOTNET=
+export TERM=xterm
+
+export TVOS_SDK="26.4"
+export TVOS_DEVICE="TVOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS${TVOS_SDK}.sdk"
+export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"
+
+rm -rf godot
+mkdir godot
+cd godot
+tar xf /root/godot.tar.gz --strip-components=1
+
+# Classical
+
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for tvOS..."
+
+  # arm64 device
+  $SCONS platform=tvos $OPTIONS arch=arm64 target=template_debug $TVOS_DEVICE $APPLE_TARGET_ARM64
+  $SCONS platform=tvos $OPTIONS arch=arm64 target=template_release $TVOS_DEVICE $APPLE_TARGET_ARM64
+
+  # tvOS simulator builds are intentionally not produced.
+
+  mkdir -p /root/out/templates
+  cp bin/libgodot.tvos.template_release.arm64.a /root/out/templates/libgodot.tvos.a
+  cp bin/libgodot.tvos.template_debug.arm64.a /root/out/templates/libgodot.tvos.debug.a
+fi
+
+# Mono
+
+if [ "${MONO}" == "1" ]; then
+  echo "Starting Mono build for tvOS..."
+
+  cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
+
+  # arm64 device
+  $SCONS platform=tvos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug $TVOS_DEVICE $APPLE_TARGET_ARM64
+  $SCONS platform=tvos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $TVOS_DEVICE $APPLE_TARGET_ARM64
+
+  # tvOS simulator builds are intentionally not produced.
+
+  mkdir -p /root/out/templates-mono
+  cp bin/libgodot.tvos.template_release.arm64.a /root/out/templates-mono/libgodot.tvos.a
+  cp bin/libgodot.tvos.template_debug.arm64.a /root/out/templates-mono/libgodot.tvos.debug.a
+fi
+
+echo "tvOS build successful"

--- a/build-visionos/build.sh
+++ b/build-visionos/build.sh
@@ -8,12 +8,12 @@ export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_
 # Keep LTO disabled for visionOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
 # Disable Vulkan and MoltenVK for visionOS - visionOS doesn't support MoltenVK.
-export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_FRONTEND=/root/.local/share/swiftly/toolchains/6.2.0/usr/bin/swift-frontend"
+export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_FRONTEND=/root/.local/share/swiftly/toolchains/6.3.0/usr/bin/swift-frontend"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm
 
-export VISIONOS_SDK="26.0"
+export VISIONOS_SDK="26.4"
 export VISIONOS_DEVICE="VISIONOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS${VISIONOS_SDK}.sdk"
 export VISIONOS_SIMULATOR="VISIONOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/XRSimulator.platform/Developer/SDKs/XRSimulator${VISIONOS_SDK}.sdk"
 export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"


### PR DESCRIPTION
Depends on:

- https://github.com/godotengine/build-containers/pull/162

Changes in this PR:

- Adds tvOS support via a new `build-tvos/build.sh`, mirroring `build-ios/build.sh` but arm64-device only (no simulator) for both Classical and Mono templates. Outputs land under `out/templates/libgodot.tvos*.a` and `out/templates-mono/libgodot.tvos*.a`.
- Bumps the iOS and visionOS SDKs from 26.1 / 26.0 to **26.4**, matching the Xcode 26.4 SDKs pulled into the `godot-appleembedded` image.
- Bumps the Swift toolchain used by the iOS and visionOS builds from 6.2.x to **6.3.0** (Apple SDK 26.4 shipped with swiftlang-6.3.0.123.x, so the OSS Swift 6.3 release is the closest marketing-version match).

Paired with the [`build-containers` PR ](https://github.com/godotengine/build-containers/pull/162) that adds the Swift 6.3 toolchain to the `godot-appleembedded` image and applies the necessary visionOS SDK patches.
