### PR TITLE
Apple: tvOS, visionOS support; use unified build container

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -4,15 +4,20 @@ set -e
 
 # Config
 
+# Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
+# fall back to a sensible default if run against an older image.
+SWIFT_VERSION="${SWIFT_VERSION:-6.3.0}"
+SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for iOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
-export OPTIONS="production=yes use_lto=no SWIFT_FRONTEND=/root/.local/share/swiftly/toolchains/6.2.1/usr/bin/swift-frontend"
+export OPTIONS="production=yes use_lto=no SWIFT_FRONTEND=${SWIFT_FRONTEND}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm
 
-export IOS_SDK="26.1"
+export IOS_SDK="26.4"
 export IOS_DEVICE="IOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS${IOS_SDK}.sdk"
 export IOS_SIMULATOR="IOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator${IOS_SDK}.sdk simulator=yes"
 export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -6,7 +6,7 @@ set -e
 
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
-SWIFT_VERSION="${SWIFT_VERSION:-6.3.0}"
+SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
 SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
@@ -17,7 +17,7 @@ export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm
 
-export IOS_SDK="26.4"
+export IOS_SDK="26.5"
 export IOS_DEVICE="IOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS${IOS_SDK}.sdk"
 export IOS_SIMULATOR="IOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator${IOS_SDK}.sdk simulator=yes"
 export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -7,16 +7,14 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
-# Swift is compiled via SWIFT_FRONTEND (swift-frontend) today; SWIFT_COMPILER
-# (swiftc) is passed too but not yet consumed by scons — ready for when the
-# visionOS PR switches setup_swift_builder to swiftc.
-SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+# Swift sources are compiled with swiftc, passed via SWIFT_COMPILER
+# (SWIFT_FRONTEND remains a back-compat alias in Godot's detect.py).
 SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for iOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
-export OPTIONS="production=yes use_lto=no SWIFT_FRONTEND=${SWIFT_FRONTEND} SWIFT_COMPILER=${SWIFT_COMPILER}"
+export OPTIONS="production=yes use_lto=no SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -7,12 +7,12 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
-SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for iOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
-export OPTIONS="production=yes use_lto=no SWIFT_FRONTEND=${SWIFT_FRONTEND}"
+export OPTIONS="production=yes use_lto=no SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm

--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -7,12 +7,16 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
+# Swift is compiled via SWIFT_FRONTEND (swift-frontend) today; SWIFT_COMPILER
+# (swiftc) is passed too but not yet consumed by scons — ready for when the
+# visionOS PR switches setup_swift_builder to swiftc.
+SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
 SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for iOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
-export OPTIONS="production=yes use_lto=no SWIFT_COMPILER=${SWIFT_COMPILER}"
+export OPTIONS="production=yes use_lto=no SWIFT_FRONTEND=${SWIFT_FRONTEND} SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm

--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -4,11 +4,35 @@ set -e
 
 # Config
 
+# Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
+# fall back to a sensible default if run against an older image.
+SWIFT_VERSION="${SWIFT_VERSION:-6.3.0}"
+SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
-export OPTIONS="osxcross_sdk=darwin25.1 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c SWIFT_FRONTEND=/root/.local/share/swiftly/toolchains/6.2.1/usr/bin/swift-frontend"
+export OPTIONS="osxcross_sdk=darwin25.4 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c SWIFT_FRONTEND=${SWIFT_FRONTEND}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm
+
+# Link config for macOS:
+#   -fuse-ld=lld                 — use LLD (not cctools-port ld, which our
+#                                  image doesn't install and whose `.tbd`
+#                                  parsing pulls in the libtapi dependency).
+#   -B /opt/darwin-tools/bin     — prepend darwin-tools to clang's program
+#                                  search so `-fuse-ld=lld` resolves to the
+#                                  Apple-platforms-enabled ld64.lld there
+#                                  (swiftly's bundled lld has Apple platforms
+#                                  disabled at build time).
+#   -L .../XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin -lclang_rt.osx
+#                                — Apple's compiler-rt from Xcode, providing
+#                                  __isPlatformVersionAtLeast for
+#                                  `if (@available(...))` / `__builtin_available`.
+#                                  Apple's clang driver auto-links this on
+#                                  macOS; osxcross-style cross-builds have to
+#                                  wire it up explicitly.
+XCODE_CLANG_RT="/root/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin"
+EXTRA_LINKFLAGS="linkflags=-fuse-ld=lld -B /opt/darwin-tools/bin -L${XCODE_CLANG_RT} -lclang_rt.osx"
 
 rm -rf godot
 mkdir godot
@@ -20,8 +44,8 @@ tar xf /root/godot.tar.gz --strip-components=1
 if [ "${CLASSICAL}" == "1" ]; then
   echo "Starting classical build for macOS..."
 
-  $SCONS platform=macos $OPTIONS arch=x86_64 target=editor
-  $SCONS platform=macos $OPTIONS arch=arm64 target=editor
+  $SCONS platform=macos $OPTIONS arch=x86_64 target=editor "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS arch=arm64 target=editor "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.editor.x86_64 bin/godot.macos.editor.arm64 -output bin/godot.macos.editor.universal
 
   mkdir -p /root/out/tools
@@ -31,8 +55,8 @@ if [ "${CLASSICAL}" == "1" ]; then
   if [ "${STEAM}" == "1" ]; then
     build_name=${BUILD_NAME}
     export BUILD_NAME="steam"
-    $SCONS platform=macos arch=x86_64 $OPTIONS target=editor steamapi=yes
-    $SCONS platform=macos arch=arm64 $OPTIONS target=editor steamapi=yes
+    $SCONS platform=macos arch=x86_64 $OPTIONS target=editor steamapi=yes "$EXTRA_LINKFLAGS"
+    $SCONS platform=macos arch=arm64 $OPTIONS target=editor steamapi=yes "$EXTRA_LINKFLAGS"
     lipo -create bin/godot.macos.editor.x86_64 bin/godot.macos.editor.arm64 -output bin/godot.macos.editor.universal
 
     mkdir -p /root/out/steam
@@ -41,11 +65,11 @@ if [ "${CLASSICAL}" == "1" ]; then
     export BUILD_NAME=${build_name}
   fi
 
-  $SCONS platform=macos $OPTIONS arch=x86_64 target=template_debug
-  $SCONS platform=macos $OPTIONS arch=arm64 target=template_debug
+  $SCONS platform=macos $OPTIONS arch=x86_64 target=template_debug "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS arch=arm64 target=template_debug "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.template_debug.x86_64 bin/godot.macos.template_debug.arm64 -output bin/godot.macos.template_debug.universal
-  $SCONS platform=macos $OPTIONS arch=x86_64 target=template_release
-  $SCONS platform=macos $OPTIONS arch=arm64 target=template_release
+  $SCONS platform=macos $OPTIONS arch=x86_64 target=template_release "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS arch=arm64 target=template_release "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.template_release.x86_64 bin/godot.macos.template_release.arm64 -output bin/godot.macos.template_release.universal
 
   mkdir -p /root/out/templates
@@ -61,8 +85,8 @@ if [ "${MONO}" == "1" ]; then
   cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
   cp -r /root/mono-glue/GodotSharp/GodotSharpEditor/Generated modules/mono/glue/GodotSharp/GodotSharpEditor/
 
-  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=editor
-  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=editor
+  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=editor "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=editor "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.editor.x86_64.mono bin/godot.macos.editor.arm64.mono -output bin/godot.macos.editor.universal.mono
   ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=macos
 
@@ -70,11 +94,11 @@ if [ "${MONO}" == "1" ]; then
   cp -rvp bin/* /root/out/tools-mono
   rm -rf bin
 
-  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_debug
-  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug
+  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_debug "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.template_debug.x86_64.mono bin/godot.macos.template_debug.arm64.mono -output bin/godot.macos.template_debug.universal.mono
-  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_release
-  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release
+  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_release "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.template_release.x86_64.mono bin/godot.macos.template_release.arm64.mono -output bin/godot.macos.template_release.universal.mono
 
   mkdir -p /root/out/templates-mono
@@ -87,19 +111,19 @@ fi
 if [ "${DOTNET}" == "1" ]; then
   echo "Starting .NET build for macOS..."
 
-  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=x86_64 target=editor
-  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=arm64 target=editor
+  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=x86_64 target=editor "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=arm64 target=editor "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.editor.x86_64.dotnet bin/godot.macos.editor.arm64.dotnet -output bin/godot.macos.editor.universal.dotnet
 
   mkdir -p /root/out/tools-dotnet
   cp -rvp bin/* /root/out/tools-dotnet
   rm -rf bin
 
-  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=x86_64 target=template_debug
-  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_debug
+  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=x86_64 target=template_debug "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_debug "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.template_debug.x86_64.dotnet bin/godot.macos.template_debug.arm64.dotnet -output bin/godot.macos.template_debug.universal.dotnet
-  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=x86_64 target=template_release
-  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_release
+  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=x86_64 target=template_release "$EXTRA_LINKFLAGS"
+  $SCONS platform=macos $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_release "$EXTRA_LINKFLAGS"
   lipo -create bin/godot.macos.template_release.x86_64.dotnet bin/godot.macos.template_release.arm64.dotnet -output bin/godot.macos.template_release.universal.dotnet
 
   mkdir -p /root/out/templates-dotnet

--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -6,11 +6,11 @@ set -e
 
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
-SWIFT_VERSION="${SWIFT_VERSION:-6.3.0}"
+SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
 SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
-export OPTIONS="osxcross_sdk=darwin25.4 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c SWIFT_FRONTEND=${SWIFT_FRONTEND}"
+export OPTIONS="osxcross_sdk=darwin25.5 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c SWIFT_FRONTEND=${SWIFT_FRONTEND}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm

--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -9,30 +9,23 @@ set -e
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
 SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
+# macOS SDK sysroot and macOS link flags are image-specific; the container
+# (godot-apple) exports them as MACOS_SDK_PATH and EXTRA_LINK_FLAGS so this
+# script doesn't hardcode paths that move with the SDK / toolchain version.
+#   MACOS_SDK_PATH   — passed to scons; detect.py uses it as the isysroot
+#                      (there is no xcrun on Linux).
+#   EXTRA_LINK_FLAGS — lld via -fuse-ld/-B, plus Xcode's clang_rt.osx.
+MACOS_SDK_PATH="${MACOS_SDK_PATH:-}"
+EXTRA_LINK_FLAGS="${EXTRA_LINK_FLAGS:-}"
+
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
-export OPTIONS="osxcross_sdk=darwin25.5 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c SWIFT_COMPILER=${SWIFT_COMPILER}"
+export OPTIONS="production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c SWIFT_COMPILER=${SWIFT_COMPILER} MACOS_SDK_PATH=${MACOS_SDK_PATH}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm
 
-# Link config for macOS:
-#   -fuse-ld=lld                 — use LLD (not cctools-port ld, which our
-#                                  image doesn't install and whose `.tbd`
-#                                  parsing pulls in the libtapi dependency).
-#   -B /opt/darwin-tools/bin     — prepend darwin-tools to clang's program
-#                                  search so `-fuse-ld=lld` resolves to the
-#                                  Apple-platforms-enabled ld64.lld there
-#                                  (swiftly's bundled lld has Apple platforms
-#                                  disabled at build time).
-#   -L .../XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin -lclang_rt.osx
-#                                — Apple's compiler-rt from Xcode, providing
-#                                  __isPlatformVersionAtLeast for
-#                                  `if (@available(...))` / `__builtin_available`.
-#                                  Apple's clang driver auto-links this on
-#                                  macOS; osxcross-style cross-builds have to
-#                                  wire it up explicitly.
-XCODE_CLANG_RT="/root/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin"
-EXTRA_LINKFLAGS="linkflags=-fuse-ld=lld -B /opt/darwin-tools/bin -L${XCODE_CLANG_RT} -lclang_rt.osx"
+# Wrap the image-provided macOS link flags in the scons `linkflags=` option.
+EXTRA_LINKFLAGS="linkflags=${EXTRA_LINK_FLAGS}"
 
 rm -rf godot
 mkdir godot

--- a/build-macos/build.sh
+++ b/build-macos/build.sh
@@ -7,10 +7,10 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
-SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
-export OPTIONS="osxcross_sdk=darwin25.5 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c SWIFT_FRONTEND=${SWIFT_FRONTEND}"
+export OPTIONS="osxcross_sdk=darwin25.5 production=yes use_volk=no vulkan_sdk_path=/root/moltenvk angle_libs=/root/angle accesskit_sdk_path=/root/accesskit/accesskit-c SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm

--- a/build-tvos/build.sh
+++ b/build-tvos/build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+# Config
+
+# Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
+# fall back to a sensible default if run against an older image.
+SWIFT_VERSION="${SWIFT_VERSION:-6.3.0}"
+SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+
+export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
+# Keep LTO disabled for tvOS - it works but it makes linking apps on deploy very slow,
+# which is seen as a regression in the current workflow (mirrors the iOS build).
+export OPTIONS="production=yes use_lto=no vulkan=no opengl3=no SWIFT_FRONTEND=${SWIFT_FRONTEND}"
+export OPTIONS_MONO="module_mono_enabled=yes"
+export OPTIONS_DOTNET=
+export TERM=xterm
+
+export TVOS_SDK="26.4"
+export TVOS_DEVICE="TVOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS${TVOS_SDK}.sdk"
+export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"
+
+rm -rf godot
+mkdir godot
+cd godot
+tar xf /root/godot.tar.gz --strip-components=1
+
+# Classical
+
+if [ "${CLASSICAL}" == "1" ]; then
+  echo "Starting classical build for tvOS..."
+
+  # arm64 device
+  $SCONS platform=tvos $OPTIONS arch=arm64 target=template_debug $TVOS_DEVICE $APPLE_TARGET_ARM64
+  $SCONS platform=tvos $OPTIONS arch=arm64 target=template_release $TVOS_DEVICE $APPLE_TARGET_ARM64
+
+  # tvOS simulator builds are intentionally not produced.
+
+  mkdir -p /root/out/templates
+  cp bin/libgodot.tvos.template_release.arm64.a /root/out/templates/libgodot.tvos.a
+  cp bin/libgodot.tvos.template_debug.arm64.a /root/out/templates/libgodot.tvos.debug.a
+fi
+
+# Mono
+
+if [ "${MONO}" == "1" ]; then
+  echo "Starting Mono build for tvOS..."
+
+  cp -r /root/mono-glue/GodotSharp/GodotSharp/Generated modules/mono/glue/GodotSharp/GodotSharp/
+
+  # arm64 device
+  $SCONS platform=tvos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug $TVOS_DEVICE $APPLE_TARGET_ARM64
+  $SCONS platform=tvos $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $TVOS_DEVICE $APPLE_TARGET_ARM64
+
+  # tvOS simulator builds are intentionally not produced.
+
+  mkdir -p /root/out/templates-mono
+  cp bin/libgodot.tvos.template_release.arm64.a /root/out/templates-mono/libgodot.tvos.a
+  cp bin/libgodot.tvos.template_debug.arm64.a /root/out/templates-mono/libgodot.tvos.debug.a
+fi
+
+echo "tvOS build successful"

--- a/build-tvos/build.sh
+++ b/build-tvos/build.sh
@@ -6,7 +6,7 @@ set -e
 
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
-SWIFT_VERSION="${SWIFT_VERSION:-6.3.0}"
+SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
 SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
@@ -17,7 +17,7 @@ export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET=
 export TERM=xterm
 
-export TVOS_SDK="26.4"
+export TVOS_SDK="26.5"
 export TVOS_DEVICE="TVOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS${TVOS_SDK}.sdk"
 export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"
 

--- a/build-tvos/build.sh
+++ b/build-tvos/build.sh
@@ -7,16 +7,14 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
-# Swift is compiled via SWIFT_FRONTEND (swift-frontend) today; SWIFT_COMPILER
-# (swiftc) is passed too but not yet consumed by scons — ready for when the
-# visionOS PR switches setup_swift_builder to swiftc.
-SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+# Swift sources are compiled with swiftc, passed via SWIFT_COMPILER
+# (SWIFT_FRONTEND remains a back-compat alias in Godot's detect.py).
 SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for tvOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow (mirrors the iOS build).
-export OPTIONS="production=yes use_lto=no vulkan=no opengl3=no SWIFT_FRONTEND=${SWIFT_FRONTEND} SWIFT_COMPILER=${SWIFT_COMPILER}"
+export OPTIONS="production=yes use_lto=no vulkan=no opengl3=no SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET=
 export TERM=xterm

--- a/build-tvos/build.sh
+++ b/build-tvos/build.sh
@@ -7,12 +7,12 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
-SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for tvOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow (mirrors the iOS build).
-export OPTIONS="production=yes use_lto=no vulkan=no opengl3=no SWIFT_FRONTEND=${SWIFT_FRONTEND}"
+export OPTIONS="production=yes use_lto=no vulkan=no opengl3=no SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET=
 export TERM=xterm

--- a/build-tvos/build.sh
+++ b/build-tvos/build.sh
@@ -7,12 +7,16 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
+# Swift is compiled via SWIFT_FRONTEND (swift-frontend) today; SWIFT_COMPILER
+# (swiftc) is passed too but not yet consumed by scons — ready for when the
+# visionOS PR switches setup_swift_builder to swiftc.
+SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
 SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for tvOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow (mirrors the iOS build).
-export OPTIONS="production=yes use_lto=no vulkan=no opengl3=no SWIFT_COMPILER=${SWIFT_COMPILER}"
+export OPTIONS="production=yes use_lto=no vulkan=no opengl3=no SWIFT_FRONTEND=${SWIFT_FRONTEND} SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET=
 export TERM=xterm

--- a/build-visionos/build.sh
+++ b/build-visionos/build.sh
@@ -4,16 +4,21 @@ set -e
 
 # Config
 
+# Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
+# fall back to a sensible default if run against an older image.
+SWIFT_VERSION="${SWIFT_VERSION:-6.3.0}"
+SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for visionOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
 # Disable Vulkan and MoltenVK for visionOS - visionOS doesn't support MoltenVK.
-export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_FRONTEND=/root/.local/share/swiftly/toolchains/6.2.0/usr/bin/swift-frontend"
+export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_FRONTEND=${SWIFT_FRONTEND}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm
 
-export VISIONOS_SDK="26.0"
+export VISIONOS_SDK="26.4"
 export VISIONOS_DEVICE="VISIONOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS${VISIONOS_SDK}.sdk"
 export VISIONOS_SIMULATOR="VISIONOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/XRSimulator.platform/Developer/SDKs/XRSimulator${VISIONOS_SDK}.sdk"
 export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"

--- a/build-visionos/build.sh
+++ b/build-visionos/build.sh
@@ -7,17 +7,15 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
-# Swift is compiled via SWIFT_FRONTEND (swift-frontend) today; SWIFT_COMPILER
-# (swiftc) is passed too but not yet consumed by scons — ready for when the
-# visionOS PR switches setup_swift_builder to swiftc.
-SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+# Swift sources are compiled with swiftc, passed via SWIFT_COMPILER
+# (SWIFT_FRONTEND remains a back-compat alias in Godot's detect.py).
 SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for visionOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
 # Disable Vulkan and MoltenVK for visionOS - visionOS doesn't support MoltenVK.
-export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_FRONTEND=${SWIFT_FRONTEND} SWIFT_COMPILER=${SWIFT_COMPILER}"
+export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm

--- a/build-visionos/build.sh
+++ b/build-visionos/build.sh
@@ -6,7 +6,7 @@ set -e
 
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
-SWIFT_VERSION="${SWIFT_VERSION:-6.3.0}"
+SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
 SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
@@ -18,7 +18,7 @@ export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm
 
-export VISIONOS_SDK="26.4"
+export VISIONOS_SDK="26.5"
 export VISIONOS_DEVICE="VISIONOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS${VISIONOS_SDK}.sdk"
 export VISIONOS_SIMULATOR="VISIONOS_SDK_PATH=/root/Xcode.app/Contents/Developer/Platforms/XRSimulator.platform/Developer/SDKs/XRSimulator${VISIONOS_SDK}.sdk"
 export APPLE_TARGET_ARM64="APPLE_TOOLCHAIN_PATH=/root/ioscross/arm64 apple_target_triple=arm-apple-darwin11-"

--- a/build-visionos/build.sh
+++ b/build-visionos/build.sh
@@ -7,13 +7,17 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
+# Swift is compiled via SWIFT_FRONTEND (swift-frontend) today; SWIFT_COMPILER
+# (swiftc) is passed too but not yet consumed by scons — ready for when the
+# visionOS PR switches setup_swift_builder to swiftc.
+SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
 SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for visionOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
 # Disable Vulkan and MoltenVK for visionOS - visionOS doesn't support MoltenVK.
-export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_COMPILER=${SWIFT_COMPILER}"
+export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_FRONTEND=${SWIFT_FRONTEND} SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm

--- a/build-visionos/build.sh
+++ b/build-visionos/build.sh
@@ -7,13 +7,13 @@ set -e
 # Swift toolchain path comes from the image (godot-apple sets SWIFT_VERSION);
 # fall back to a sensible default if run against an older image.
 SWIFT_VERSION="${SWIFT_VERSION:-6.3.2}"
-SWIFT_FRONTEND="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swift-frontend"
+SWIFT_COMPILER="/root/.local/share/swiftly/toolchains/${SWIFT_VERSION}/usr/bin/swiftc"
 
 export SCONS="scons -j${NUM_CORES} verbose=yes warnings=no progress=no redirect_build_objects=no"
 # Keep LTO disabled for visionOS - it works but it makes linking apps on deploy very slow,
 # which is seen as a regression in the current workflow.
 # Disable Vulkan and MoltenVK for visionOS - visionOS doesn't support MoltenVK.
-export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_FRONTEND=${SWIFT_FRONTEND}"
+export OPTIONS="production=yes use_lto=no vulkan=no SWIFT_COMPILER=${SWIFT_COMPILER}"
 export OPTIONS_MONO="module_mono_enabled=yes"
 export OPTIONS_DOTNET="module_dotnet_enabled=yes"
 export TERM=xterm

--- a/build.sh
+++ b/build.sh
@@ -297,16 +297,20 @@ mkdir -p ${basedir}/out/web
 ${podman_run} -v ${basedir}/build-web:/root/build -v ${basedir}/out/web:/root/out localhost/godot-web:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/web
 
 mkdir -p ${basedir}/out/macos
-${podman_run} -v ${basedir}/build-macos:/root/build -v ${basedir}/out/macos:/root/out -v ${basedir}/deps/accesskit:/root/accesskit -v ${basedir}/deps/moltenvk:/root/moltenvk -v ${basedir}/deps/angle:/root/angle --env STEAM=${build_steam} localhost/godot-osx:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/macos
+${podman_run} -v ${basedir}/build-macos:/root/build -v ${basedir}/out/macos:/root/out -v ${basedir}/deps/accesskit:/root/accesskit -v ${basedir}/deps/moltenvk:/root/moltenvk -v ${basedir}/deps/angle:/root/angle --env STEAM=${build_steam} localhost/godot-apple:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/macos
 
 mkdir -p ${basedir}/out/android
 ${podman_run} -v ${basedir}/build-android:/root/build -v ${basedir}/out/android:/root/out -v ${basedir}/deps/swappy:/root/swappy -v ${basedir}/deps/keystore:/root/keystore localhost/godot-android:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/android
 
 mkdir -p ${basedir}/out/ios
-${podman_run} -v ${basedir}/build-ios:/root/build -v ${basedir}/out/ios:/root/out localhost/godot-appleembedded:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/ios
+${podman_run} -v ${basedir}/build-ios:/root/build -v ${basedir}/out/ios:/root/out localhost/godot-apple:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/ios
 
-#mkdir -p ${basedir}/out/visionos
-#${podman_run} -v ${basedir}/build-visionos:/root/build -v ${basedir}/out/visionos:/root/out localhost/godot-appleembedded:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/visionos
+# TODO(sgc): Enable when tvOS is available.
+# mkdir -p ${basedir}/out/tvos
+# ${podman_run} -v ${basedir}/build-tvos:/root/build -v ${basedir}/out/tvos:/root/out localhost/godot-apple:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/tvos
+
+mkdir -p ${basedir}/out/visionos
+${podman_run} -v ${basedir}/build-visionos:/root/build -v ${basedir}/out/visionos:/root/out localhost/godot-apple:${img_version} bash build/build.sh 2>&1 | tee ${basedir}/out/logs/visionos
 
 uid=$(id -un)
 gid=$(id -gn)

--- a/build.sh
+++ b/build.sh
@@ -158,8 +158,8 @@ if [ ! -d "deps/moltenvk" ]; then
   echo "Missing MoltenVK for macOS/iOS, downloading it."
   mkdir -p deps/moltenvk
   pushd deps/moltenvk
-  curl -LO https://github.com/godotengine/moltenvk-osxcross/releases/download/moltenvk-1.4.1/MoltenVK-all.tar.xz
-  tar xvf MoltenVK-all.tar.xz && rm -f MoltenVK-all.tar.xz
+  curl -LO https://github.com/KhronosGroup/MoltenVK/releases/download/v1.4.1/MoltenVK-all.tar
+  tar xvf MoltenVK-all.tar && rm -f MoltenVK-all.tar
   mv MoltenVK/MoltenVK/include/ MoltenVK/
   mv MoltenVK/MoltenVK/static/MoltenVK.xcframework/ MoltenVK/
   popd


### PR DESCRIPTION
* Updated to use new build container, godot-apple
* Adds visionOS target
* Adds support for tvOS but does not compile yet as depends on:
    * https://github.com/godotengine/godot/pull/118332

Depends on:

- https://github.com/godotengine/build-containers/pull/163
- https://github.com/godotengine/godot/pull/121255

# Testing

- Built the macOS editor App
- Build the templates for iOS and visionOS
- Generated the tpz export archive
- Ran the editor on macOS and exported the Platformer 2D to iOS and visionOS and successfully compiled the binaries under Xcode.