### PR TITLE
visionOS: Generate the classical templates archive

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -378,17 +378,17 @@ if [ "${build_classical}" == "1" ]; then
 
   ## visionOS (Classical) ##
 
-  #rm -rf visionos_xcode
-  #cp -r git/misc/dist/apple_embedded_xcode visionos_xcode
-  #cp out/visionos/templates/libgodot.visionos.a visionos_xcode/libgodot.visionos.release.xcframework/xros-arm64/libgodot.a
-  #cp out/visionos/templates/libgodot.visionos.debug.a visionos_xcode/libgodot.visionos.debug.xcframework/xros-arm64/libgodot.a
-  #cp out/visionos/templates/libgodot_camera.visionos.a visionos_xcode/libgodot_camera.visionos.release.xcframework/xros-arm64/libgodot_camera.a
-  #cp out/visionos/templates/libgodot_camera.visionos.debug.a visionos_xcode/libgodot_camera.visionos.debug.xcframework/xros-arm64/libgodot_camera.a
-  #rm -rf visionos_xcode/libgodot.ios.*
-  #cd visionos_xcode
-  #zip -q -9 -r "${templatesdir}/visionos.zip" *
-  #cd ..
-  #rm -rf visionos_xcode
+  rm -rf visionos_xcode
+  cp -r git/misc/dist/apple_embedded_xcode visionos_xcode
+  cp out/visionos/templates/libgodot.visionos.a visionos_xcode/libgodot.visionos.release.xcframework/xros-arm64/libgodot.a
+  cp out/visionos/templates/libgodot.visionos.debug.a visionos_xcode/libgodot.visionos.debug.xcframework/xros-arm64/libgodot.a
+  cp out/visionos/templates/libgodot_camera.visionos.a visionos_xcode/libgodot_camera.visionos.release.xcframework/xros-arm64/libgodot_camera.a
+  cp out/visionos/templates/libgodot_camera.visionos.debug.a visionos_xcode/libgodot_camera.visionos.debug.xcframework/xros-arm64/libgodot_camera.a
+  rm -rf visionos_xcode/libgodot.ios.*
+  cd visionos_xcode
+  zip -q -9 -r "${templatesdir}/visionos.zip" *
+  cd ..
+  rm -rf visionos_xcode
 
   ## Templates TPZ (Classical) ##
 


### PR DESCRIPTION
Uncomment the steps to archive the classical visionOS templates.

Depends on:

- https://github.com/godotengine/godot/pull/122559