### PR TITLE
iOS: Re-enable arm64 simulator builds

### DIFF
--- a/build-ios/build.sh
+++ b/build-ios/build.sh
@@ -32,10 +32,8 @@ if [ "${CLASSICAL}" == "1" ]; then
   $SCONS platform=ios $OPTIONS arch=arm64 target=template_release $IOS_DEVICE $APPLE_TARGET_ARM64
 
   # arm64 simulator
-  # Disabled for now as it doesn't work with cctools-port and current LLVM.
-  # See https://github.com/godotengine/build-containers/pull/85.
-  #$SCONS platform=ios $OPTIONS arch=arm64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_ARM64
-  #$SCONS platform=ios $OPTIONS arch=arm64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_ARM64
+  $SCONS platform=ios $OPTIONS arch=arm64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_ARM64
+  $SCONS platform=ios $OPTIONS arch=arm64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_ARM64
 
   # x86_64 simulator
   $SCONS platform=ios $OPTIONS arch=x86_64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_X86_64
@@ -46,10 +44,10 @@ if [ "${CLASSICAL}" == "1" ]; then
   cp bin/libgodot.ios.template_debug.arm64.a /root/out/templates/libgodot.ios.debug.a
   cp bin/libgodot_camera.ios.template_release.arm64.a /root/out/templates/libgodot_camera.ios.a
   cp bin/libgodot_camera.ios.template_debug.arm64.a /root/out/templates/libgodot_camera.ios.debug.a
-  cp bin/libgodot.ios.template_release.x86_64.simulator.a /root/out/templates/libgodot.ios.simulator.a
-  cp bin/libgodot.ios.template_debug.x86_64.simulator.a /root/out/templates/libgodot.ios.debug.simulator.a
-  cp bin/libgodot_camera.ios.template_release.x86_64.simulator.a /root/out/templates/libgodot_camera.ios.simulator.a
-  cp bin/libgodot_camera.ios.template_debug.x86_64.simulator.a /root/out/templates/libgodot_camera.ios.debug.simulator.a
+  lipo -create bin/libgodot.ios.template_release.arm64.simulator.a bin/libgodot.ios.template_release.x86_64.simulator.a -output /root/out/templates/libgodot.ios.simulator.a
+  lipo -create bin/libgodot.ios.template_debug.arm64.simulator.a bin/libgodot.ios.template_debug.x86_64.simulator.a -output /root/out/templates/libgodot.ios.debug.simulator.a
+  lipo -create bin/libgodot_camera.ios.template_release.arm64.simulator.a bin/libgodot_camera.ios.template_release.x86_64.simulator.a -output /root/out/templates/libgodot_camera.ios.simulator.a
+  lipo -create bin/libgodot_camera.ios.template_debug.arm64.simulator.a bin/libgodot_camera.ios.template_debug.x86_64.simulator.a -output /root/out/templates/libgodot_camera.ios.debug.simulator.a
 fi
 
 # Mono
@@ -64,10 +62,8 @@ if [ "${MONO}" == "1" ]; then
   $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $IOS_DEVICE $APPLE_TARGET_ARM64
 
   # arm64 simulator
-  # Disabled for now as it doesn't work with cctools-port and current LLVM.
-  # See https://github.com/godotengine/build-containers/pull/85.
-  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_ARM64
-  #$SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_ARM64
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_ARM64
+  $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=arm64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_ARM64
 
   # x86_64 simulator
   $SCONS platform=ios $OPTIONS $OPTIONS_MONO arch=x86_64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_X86_64
@@ -78,10 +74,10 @@ if [ "${MONO}" == "1" ]; then
   cp bin/libgodot.ios.template_debug.arm64.a /root/out/templates-mono/libgodot.ios.debug.a
   cp bin/libgodot_camera.ios.template_release.arm64.a /root/out/templates-mono/libgodot_camera.ios.a
   cp bin/libgodot_camera.ios.template_debug.arm64.a /root/out/templates-mono/libgodot_camera.ios.debug.a
-  cp bin/libgodot.ios.template_release.x86_64.simulator.a /root/out/templates-mono/libgodot.ios.simulator.a
-  cp bin/libgodot.ios.template_debug.x86_64.simulator.a /root/out/templates-mono/libgodot.ios.debug.simulator.a
-  cp bin/libgodot_camera.ios.template_release.x86_64.simulator.a /root/out/templates-mono/libgodot_camera.ios.simulator.a
-  cp bin/libgodot_camera.ios.template_debug.x86_64.simulator.a /root/out/templates-mono/libgodot_camera.ios.debug.simulator.a
+  lipo -create bin/libgodot.ios.template_release.arm64.simulator.a bin/libgodot.ios.template_release.x86_64.simulator.a -output /root/out/templates-mono/libgodot.ios.simulator.a
+  lipo -create bin/libgodot.ios.template_debug.arm64.simulator.a bin/libgodot.ios.template_debug.x86_64.simulator.a -output /root/out/templates-mono/libgodot.ios.debug.simulator.a
+  lipo -create bin/libgodot_camera.ios.template_release.arm64.simulator.a bin/libgodot_camera.ios.template_release.x86_64.simulator.a -output /root/out/templates-mono/libgodot_camera.ios.simulator.a
+  lipo -create bin/libgodot_camera.ios.template_debug.arm64.simulator.a bin/libgodot_camera.ios.template_debug.x86_64.simulator.a -output /root/out/templates-mono/libgodot_camera.ios.debug.simulator.a
 fi
 
 # .NET
@@ -94,10 +90,8 @@ if [ "${DOTNET}" == "1" ]; then
   $SCONS platform=ios $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_release $IOS_DEVICE $APPLE_TARGET_ARM64
 
   # arm64 simulator
-  # Disabled for now as it doesn't work with cctools-port and current LLVM.
-  # See https://github.com/godotengine/build-containers/pull/85.
-  #$SCONS platform=ios $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_ARM64
-  #$SCONS platform=ios $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_ARM64
+  $SCONS platform=ios $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_ARM64
+  $SCONS platform=ios $OPTIONS $OPTIONS_DOTNET arch=arm64 target=template_release $IOS_SIMULATOR $APPLE_TARGET_ARM64
 
   # x86_64 simulator
   $SCONS platform=ios $OPTIONS $OPTIONS_DOTNET arch=x86_64 target=template_debug $IOS_SIMULATOR $APPLE_TARGET_X86_64
@@ -108,10 +102,10 @@ if [ "${DOTNET}" == "1" ]; then
   cp bin/libgodot.ios.template_debug.arm64.a /root/out/templates-dotnet/libgodot.ios.debug.a
   cp bin/libgodot_camera.ios.template_release.arm64.a /root/out/templates-dotnet/libgodot_camera.ios.a
   cp bin/libgodot_camera.ios.template_debug.arm64.a /root/out/templates-dotnet/libgodot_camera.ios.debug.a
-  cp bin/libgodot.ios.template_release.x86_64.simulator.a /root/out/templates-dotnet/libgodot.ios.simulator.a
-  cp bin/libgodot.ios.template_debug.x86_64.simulator.a /root/out/templates-dotnet/libgodot.ios.debug.simulator.a
-  cp bin/libgodot_camera.ios.template_release.x86_64.simulator.a /root/out/templates-dotnet/libgodot_camera.ios.simulator.a
-  cp bin/libgodot_camera.ios.template_debug.x86_64.simulator.a /root/out/templates-dotnet/libgodot_camera.ios.debug.simulator.a
+  lipo -create bin/libgodot.ios.template_release.arm64.simulator.a bin/libgodot.ios.template_release.x86_64.simulator.a -output /root/out/templates-dotnet/libgodot.ios.simulator.a
+  lipo -create bin/libgodot.ios.template_debug.arm64.simulator.a bin/libgodot.ios.template_debug.x86_64.simulator.a -output /root/out/templates-dotnet/libgodot.ios.debug.simulator.a
+  lipo -create bin/libgodot_camera.ios.template_release.arm64.simulator.a bin/libgodot_camera.ios.template_release.x86_64.simulator.a -output /root/out/templates-dotnet/libgodot_camera.ios.simulator.a
+  lipo -create bin/libgodot_camera.ios.template_debug.arm64.simulator.a bin/libgodot_camera.ios.template_debug.x86_64.simulator.a -output /root/out/templates-dotnet/libgodot_camera.ios.debug.simulator.a
 fi
 
 echo "iOS build successful"


### PR DESCRIPTION
The arm64 simulator lines were commented out in 2021 because cctools-port and the LLVM of that time could not build them. Dockerfile.apple does not use cctools-port or osxcross any more, so that reason no longer applies.

This uncomments those lines and joins the arm64 and x86_64 simulator archives with lipo. Today only the x86_64 one is copied, even though the xcframework Info.plist says the slice holds both.

What I ran, on macOS with Xcode's clang, against godot master 9ba32b09e0:

```
scons platform=ios arch=arm64 ios_simulator=yes target=template_debug
scons platform=ios arch=x86_64 ios_simulator=yes target=template_debug
llvm-lipo -create bin/libgodot.ios.template_debug.arm64.simulator.a bin/libgodot.ios.template_debug.x86_64.simulator.a -output libgodot.ios.debug.simulator.a

$ lipo -info libgodot.ios.debug.simulator.a
Architectures in the fat file: libgodot.ios.debug.simulator.a are: x86_64 arm64
```

To try it yourself without the container, take that archive and replace this file in any project exported for iOS with "export project only" on:

```
<name>.xcframework/ios-arm64_x86_64-simulator/libgodot.a
```

Then open the xcodeproj, pick an iPhone simulator and build. Before the swap it fails with `found architecture 'x86_64', required architecture 'arm64'`. After it builds and runs.

I have not run this inside godot-apple. I have no podman on this machine, so someone with the container should check that swiftly's clang behaves the same as Xcode's here.

build-containers needs no change, lipo is already on PATH there and build-macos/build.sh uses it the same way. This is iOS only. build-visionos has the same commented lines, but nothing copies its simulator output and the visionOS copies in build-release.sh are commented out, so there is nothing to ship there yet.
